### PR TITLE
feat(infra): serve jit hls via nginx-vod (phase 5)

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -48,7 +48,8 @@
     "pyright": {
       "settings": {
         "python.analysis.typeCheckingMode": "basic",
-        "python.analysis.diagnosticMode": "workspace"
+        "python.analysis.diagnosticMode": "workspace",
+        "python.analysis.extraPaths": ["services/auth", "services/transcoder"]
       }
     },
     "gopls": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 ### Стек и структура (кратко)
 
 - **Go (chi `go-chi/chi/v5`):** `services/gateway`, `services/metadata`, `services/upload` — `golang:1.27-alpine`, `pgx`, `zerolog`, `amqp091-go`. Версионирование `/api/v1`.
-- **Python (FastAPI + Celery + uv):** `services/auth` (`src/main.py:1`), `services/transcoder` (`app/celery_app.py:1`, `app/tasks.py:1`) — `python:3.11-slim`, `uv`, `argon2`, `aiobotocore`, `ffmpeg-python`.
+- **Python (FastAPI + Celery + uv):** `services/auth` (`src/main.py:1`), `services/transcoder` (`app/celery_app.py:1`, `app/tasks.py:1`) — `python:3.14-slim`, `uv`, `argon2`, `aiobotocore`, `ffmpeg-python`.
 - **Infra:** `deploy/docker-compose.yml:1` — `postgres:16-alpine :5432`, `minio/minio :9000/:9001`, `rabbitmq:3-management :5672/:15672`, `nginx-vod :8081`, `gateway :8080`, `frontend :3000`.
 - **Frontend:** `frontend/` — Next.js 14 App Router + `hls.js` + `zustand` + `tailwind`.
 - **Transcoding JIT:** храним 3 MP4/рип (360/720/1080) с `-force_key_frames "expr:gte(t,n_forced*2)"` и `-sc_threshold 0` (`docs/spec.md:82`), nginx-vod режет на сегменты.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,124 @@
+# AGENTS.md — Flowix guidelines
+
+> Источник принципов: [multica-ai/andrej-karpathy-skills](https://github.com/multica-ai/andrej-karpathy-skills) (Andrej Karpathy observations). Логика проекта — `docs/spec.md:1` и `docs/services-pipeline.md:1`.
+
+Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.
+
+---
+
+## Project-Specific Guidelines — Flowix
+
+### Где логика проекта (ходи сюда для уточнения)
+
+- **ТЗ и архитектура (бывший AGENTS.md):** `docs/spec.md:1` — стек, структура монорепо, описание каждого микросервиса, FFmpeg-параметры, кодстайл, коммит-конвенции.
+- **Сервисы и пайплайн (на русском):** `docs/services-pipeline.md:1` — зачем каждый сервис (gateway/auth/metadata/upload/transcoder/nginx-vod/frontend) и полный пайплайн `upload → RabbitMQ → transcode → MinIO → HLS` с диаграммой и сценариями отладки.
+- **План по фазам:** `docs/PLAN.md:1` — 8 фаз, граф зависимостей, DDL `deploy/postgres/init.sql:1`, контракты событий `video.uploaded`/`video.transcoded`.
+- **Swagger / Zed:** `docs/SWAGGER.md:1`, `docs/ZED.md:1` — генерация OpenAPI для Go, настройки IDE.
+
+### Стек и структура (кратко)
+
+- **Go (chi `go-chi/chi/v5`):** `services/gateway`, `services/metadata`, `services/upload` — `golang:1.27-alpine`, `pgx`, `zerolog`, `amqp091-go`. Версионирование `/api/v1`.
+- **Python (FastAPI + Celery + uv):** `services/auth` (`src/main.py:1`), `services/transcoder` (`app/celery_app.py:1`, `app/tasks.py:1`) — `python:3.14-slim`, `uv`, `argon2`, `aiobotocore`, `ffmpeg-python`.
+- **Infra:** `deploy/docker-compose.yml:1` — `postgres:16-alpine :5432`, `minio/minio :9000/:9001`, `rabbitmq:3-management :5672/:15672`, `nginx-vod :8081`, `gateway :8080`, `frontend :3000`.
+- **Frontend:** `frontend/` — Next.js 14 App Router + `hls.js` + `zustand` + `tailwind`.
+- **Transcoding JIT:** храним 3 MP4/рип (360/720/1080) с `-force_key_frames "expr:gte(t,n_forced*2)"` и `-sc_threshold 0` (`docs/spec.md:82`), nginx-vod режет на сегменты.
+
+### Команды (via Makefile)
+
+```bash
+cp .env.example .env
+make up        # docker compose --env-file .env -f deploy/docker-compose.yml up --build -d
+make logs && make ps
+make lint-py && make lint-go && make lint-front
+make fmt-py && make fmt-go
+make test-go && make test-py
+make swagger   # swag init для metadata+upload
+make e2e       # scripts/e2e.sh — upload→transcode→hls
+```
+
+Локально без Docker: `make dev-auth` (`:8001`), `make dev-transcoder` (Celery), `make dev-metadata` (`:8002`), `make dev-upload` (`:8003`), `make dev-gateway` (`:8080`), `make dev-frontend` (`:3000`).
+
+### Кодстайл
+
+- Go: `gofmt`, `golangci-lint`, DI, `context.Context`, `zerolog`, вешай `// @Summary` для Swagger.
+- Python: `black` (100), `flake8`, `mypy`, type hints обязательны, Pydantic для событий, `ruff --fix` в Zed.
+- Frontend: `eslint` + `prettier`, функц. компоненты, `zustand` (не Redux).
+- Тесты критичной логики обязательны; `docker-compose` для интеграционных.
+
+### Микросервис-гайд
+
+- Новый сервис → `services/<name>/` + `Dockerfile` + `go.mod`/`pyproject.toml` → допиши `deploy/docker-compose.yml:1` и `.env.example:1`.
+- Тяжёлую работу — в очередь (RabbitMQ/Celery), не в хэндлерах.
+- Меняешь контракт — обнови `.proto`/Pydantic/Go struct + `docs/spec.md:73` + README сервиса.
+
+### Коммиты — Conventional Commits
+
+`type(scope): short lower-case imperative` — см. `docs/spec.md:256`. Header ≤72, атомарно по scope (`auth`, `transcoder`, `gateway`, `metadata`, `upload`, `frontend`, `infra`, `docs`...), не мешай скоупы. Never commit `.env`, `__pycache__/`, `node_modules/`, `data/`, `tmp/`.
+
+### Для ИИ-агентов в этом репо
+
+- Перед правкой сервиса — читай его `services/*/README.md:1` + `docs/services-pipeline.md:1`.
+- Обновляй тесты и доку вместе с кодом; новые env — в `.env.example:1`.
+- Следуй 4 принципам выше: думай → упрощай → хирургически → верифицируй (тест до/после).

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # .env — единственный в корне, compose явно указывает на него (--env-file), deploy/.env не нужен
 COMPOSE=docker compose --env-file .env -f deploy/docker-compose.yml
 
-.PHONY: up down logs ps build lint fmt test e2e swagger swagger-install
+.PHONY: up down logs ps build lint fmt test e2e swagger swagger-install sync-py
 
 up:
 	$(COMPOSE) up --build -d
@@ -48,26 +48,31 @@ test-go:
 
 # Python (uv) — пути абсолютные из корня, т.к. uv --project не меняет cwd
 lint-py:
-	uv run --project services/auth black --check services/auth/src --target-version py311
-	uv run --project services/transcoder black --check services/transcoder/app --target-version py311
+	uv run --project services/auth black --check services/auth/src --target-version py314
+	uv run --project services/transcoder black --check services/transcoder/app --target-version py314
 	uv run --project services/auth flake8 services/auth/src
 	uv run --project services/transcoder flake8 services/transcoder/app
 	uv run --project services/auth mypy services/auth/src
 	uv run --project services/transcoder mypy services/transcoder/app
 
 fmt-py:
-	uv run --project services/auth black services/auth/src --target-version py311
-	uv run --project services/transcoder black services/transcoder/app --target-version py311
+	uv run --project services/auth black services/auth/src --target-version py314
+	uv run --project services/transcoder black services/transcoder/app --target-version py314
 	uv run --project services/auth ruff check --select I --fix services/auth/src 2>/dev/null || uv run --project services/auth isort services/auth/src 2>/dev/null || true
 
 fix-py:
 	uv run --project services/auth ruff check --fix services/auth/src 2>/dev/null || true
-	uv run --project services/auth black services/auth/src --target-version py311
-	uv run --project services/transcoder black services/transcoder/app --target-version py311
+	uv run --project services/auth black services/auth/src --target-version py314
+	uv run --project services/transcoder black services/transcoder/app --target-version py314
 
 test-py:
 	uv run --project services/auth pytest services/auth/tests -q
 	uv run --project services/transcoder pytest services/transcoder/tests -q
+
+# Python deps — uv sync для обоих сервисов (после изменения pyproject.toml / Python версии)
+sync-py:
+	uv sync --project services/auth
+	uv sync --project services/transcoder
 
 # local dev via uv / go (требует Go 1.27 локально, иначе используй docker compose up)
 dev-auth:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > YouTube-like MVP with adaptive HLS, JIT transcoding and microservices architecture
 
 [![Go](https://img.shields.io/badge/Go-1.23-%2300ADD8?logo=go)](https://go.dev)
-[![Python](https://img.shields.io/badge/Python-3.11-%233770A8?logo=python)](https://www.python.org)
+[![Python](https://img.shields.io/badge/Python-3.14-%233770A8?logo=python)](https://www.python.org)
 [![FastAPI](https://img.shields.io/badge/FastAPI-0.11-%23009688?logo=fastapi)](https://fastapi.tiangolo.com)
 [![Next.js](https://img.shields.io/badge/Next.js-14-black?logo=next.js)](https://nextjs.org)
 [![Docker](https://img.shields.io/badge/Docker-Compose-%232496ED?logo=docker)](deploy/docker-compose.yml)
@@ -42,7 +42,7 @@
 | Layer | Tech |
 |-------|------|
 | Gateway / Metadata / Upload | Go 1.23, `go-chi/chi/v5`, `pgx`, `zerolog`, `amqp091-go` |
-| Auth / Transcoder | Python 3.11, FastAPI, Celery, `uv`, `argon2`, `aiobotocore`, `ffmpeg-python` |
+| Auth / Transcoder | Python 3.14, FastAPI, Celery, `uv`, `argon2`, `aiobotocore`, `ffmpeg-python` |
 | Infra | Postgres 16, MinIO, RabbitMQ 3, `nginx-vod-module`, FFmpeg |
 | Frontend | Next.js 14, `hls.js` 1.5, `zustand` 4, Tailwind |
 | Tooling | Docker Compose, `golangci-lint`, `black`/`ruff`/`mypy`, `eslint`/`prettier` |

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -63,16 +63,16 @@ services:
       interval: 10s
       retries: 10
 
-  # Placeholder nginx-vod — replaced with custom build in Phase 5
+  # Phase 5: nginx-vod JIT (kaltura/nginx-vod-module) — maps 3 MP4s to HLS via MinIO
   nginx-vod:
-    image: nginx:alpine
+    build: ./nginx
     depends_on:
       minio:
         condition: service_healthy
+      metadata:
+        condition: service_started
     ports:
       - "${NGINX_VOD_PORT:-8081}:80"
-    volumes:
-      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:80/health"]
       interval: 10s

--- a/deploy/nginx/Dockerfile
+++ b/deploy/nginx/Dockerfile
@@ -1,0 +1,36 @@
+ARG NGINX_VERSION=1.25.5
+FROM nginx:${NGINX_VERSION}-alpine AS builder
+
+# Build deps for nginx-vod-module (ffmpeg for thumbnail, openssl for DRM, libxml2 for DFXP)
+RUN apk add --no-cache \
+    git \
+    build-base \
+    pcre-dev \
+    zlib-dev \
+    openssl-dev \
+    ffmpeg-dev \
+    libxml2-dev \
+    curl
+
+RUN git clone --depth 1 https://github.com/kaltura/nginx-vod-module.git /usr/src/nginx-vod-module
+
+# Download nginx source matching the base image
+RUN wget -O /tmp/nginx.tar.gz http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz \
+    && tar -xzf /tmp/nginx.tar.gz -C /tmp
+
+RUN cd /tmp/nginx-${NGINX_VERSION} \
+    && ./configure \
+        --with-compat \
+        --add-dynamic-module=/usr/src/nginx-vod-module \
+        --with-cc-opt="-O3" \
+    && make modules
+
+FROM nginx:${NGINX_VERSION}-alpine
+# ffmpeg libs for vod thumbnail/volume_map (optional but needed for JIT)
+RUN apk add --no-cache ffmpeg libxml2
+
+COPY --from=builder /tmp/nginx-${NGINX_VERSION}/objs/ngx_http_vod_module.so /usr/lib/nginx/modules/ngx_http_vod_module.so
+COPY nginx.conf /etc/nginx/nginx.conf
+
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/deploy/nginx/nginx.conf
+++ b/deploy/nginx/nginx.conf
@@ -1,41 +1,64 @@
-worker_processes  auto;
+load_module modules/ngx_http_vod_module.so;
+
+worker_processes auto;
+
 events { worker_connections 1024; }
 
 http {
   access_log /var/log/nginx/access.log;
-  error_log /var/log/nginx/error.log;
+  error_log /var/log/nginx/error.log warn;
 
-  # Phase 0 placeholder — health + reverse to MinIO
-  # Phase 5: replace with nginx-vod JIT config:
-  #   vod_mode mapped;
-  #   vod_upstream_location /minio;
-  # For now, serve health and proxy /minio/* for debugging.
+  include mime.types;
+  default_type application/octet-stream;
+  sendfile on;
+  tcp_nodelay on;
 
-  # Resolver для compose-сети (127.0.0.11 — Docker embedded DNS)
-  # Variable делает резолв lazy — тест проходит без сети
+  vod_metadata_cache metadata_cache 512m;
+  vod_mapping_cache mapping_cache 5m;
+  vod_response_cache response_cache 128m;
+  vod_max_mapping_response_size 16k;
+  vod_max_upstream_headers_size 4k;
+  vod_last_modified_types *;
+  vod_segment_duration 2000;
+  vod_align_segments_to_key_frames on;
+  vod_manifest_segment_durations_mode accurate;
   resolver 127.0.0.11 valid=30s;
 
   server {
     listen 80;
 
-    location /health {
-      return 200 'ok';
+    add_header Access-Control-Allow-Origin "*" always;
+    add_header Access-Control-Allow-Methods "GET, HEAD, OPTIONS" always;
+    add_header Access-Control-Allow-Headers "*" always;
+
+    location = /health {
       add_header Content-Type text/plain;
+      return 200 "ok\n";
     }
 
-    # Debug: proxy to MinIO to verify bucket access (через variable для lazy-resolve)
-    location /minio/ {
-      set $minio_upstream http://minio:9000;
-      proxy_pass $minio_upstream/;
-      proxy_set_header Host $host;
+    # nginx-vod fetches the mapping at /mapping/hls/<video_id> for an HLS URL.
+    location ~ "^/mapping/(?:hls/)?(?<video_id>[0-9a-fA-F-]{36})$" {
+      internal;
+      proxy_pass http://metadata:8002/internal/videos/$video_id/vod;
+      proxy_set_header Host metadata;
     }
 
-    # Phase 5 will add:
-    # location /hls/ {
-    #   vod hls;
-    #   vod_mode mapped;
-    #   vod_upstream_location /minio;
-    #   vod_bootstrap_args "bucket=videos";
-    # }
+    # Mapping paths are object keys relative to the configured MinIO bucket.
+    location ^~ /minio/ {
+      internal;
+      proxy_pass http://minio:9000/videos/;
+      proxy_set_header Host minio;
+      proxy_buffering off;
+    }
+
+    location ~ "^/hls/[0-9a-fA-F-]{36}/" {
+      vod hls;
+      vod_mode mapped;
+      vod_upstream_location /mapping;
+      vod_remote_upstream_location /minio;
+
+      expires 1d;
+      add_header Cache-Control "public, max-age=86400";
+    }
   }
 }

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -78,7 +78,7 @@ CREATE TABLE video_renditions (video_id UUID REFERENCES videos(id) ON DELETE CAS
 
 ## Фаза 2a — Auth Service (Python, FastAPI) `AGENTS.md:70-75`
 
-**Структура:** `services/auth/src/{main.py, routers/auth.py, models.py, schemas.py, core/{security.py,config.py}}`, `pyproject.toml`, `Dockerfile` `python:3.11-slim`
+**Структура:** `services/auth/src/{main.py, routers/auth.py, models.py, schemas.py, core/{security.py,config.py}}`, `pyproject.toml`, `Dockerfile` `python:3.14-slim`
 
 **Эндпоинты:** `POST /api/v1/auth/register`, `POST /api/v1/auth/login`, `POST /api/v1/auth/refresh`, `GET /api/v1/auth/me` (защищен)
 
@@ -111,7 +111,7 @@ CREATE TABLE video_renditions (video_id UUID REFERENCES videos(id) ON DELETE CAS
 
 ## Фаза 4 — Transcoder Worker (Celery + RabbitMQ) `AGENTS.md:76-85`
 
-**Структура:** `services/transcoder/app/{celery_app.py,tasks.py,schemas.py,minio_client.py}`, `Dockerfile` `python:3.11 + ffmpeg`
+**Структура:** `services/transcoder/app/{celery_app.py,tasks.py,schemas.py,minio_client.py}`, `Dockerfile` `python:3.14 + ffmpeg`
 
 **Воркер:**
 `consume video.uploaded → download raw → ffprobe (fps/duration) → 3× ffmpeg параллельно → upload renditions/{id}/{360,720,1080}.mp4 → PATCH metadata ready → publish video.transcoded`

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -101,7 +101,7 @@ Each service has its own `Dockerfile` and can be developed independently.
 ### Prerequisites
 - Docker and Docker Compose
 - Go 1.21+
-- Python 3.11+
+- Python 3.14+
 - Node.js 20+ (for frontend)
 - FFmpeg (for local testing)
 

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,4 @@
+{
+  "typeCheckingMode": "basic",
+  "extraPaths": ["services/auth", "services/transcoder"]
+}

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -1,9 +1,156 @@
 #!/usr/bin/env bash
+# Flowix end-to-end check: upload → transcode → HLS (Phase 5 nginx-vod JIT acceptance).
+#
+# Two modes:
+#   Full pipeline (default): register → login → upload sample → poll ready → assert HLS.
+#   Phase-5 only:            VIDEO_ID=<id> ./scripts/e2e.sh   # skip upload, assert HLS for a ready video.
+#
+# Gateway is a stub until Phase 6, so services are hit directly on their own ports.
+# Override any endpoint via env, e.g. VOD=http://localhost:8080 once the gateway proxies /hls.
+#
+#   make up            # bring the stack up first
+#   make e2e           # or: bash scripts/e2e.sh
 set -euo pipefail
-GATEWAY=${GATEWAY:-http://localhost:8080}
-echo "[e2e] gateway=$GATEWAY"
-echo "[e2e] 1) health"
-curl -sf "$GATEWAY/health" || curl -sf http://localhost:8081/health || echo "health not yet"
-echo "[e2e] 2) register/login"
-# TODO: implement after auth service
-echo "[e2e] placeholder — implement after Phase 2"
+
+AUTH=${AUTH:-http://localhost:8001}
+UPLOAD=${UPLOAD:-http://localhost:8003}
+METADATA=${METADATA:-http://localhost:8002}
+VOD=${VOD:-http://localhost:8081}
+
+EMAIL=${EMAIL:-user@example.com}
+PASSWORD=${PASSWORD:-string}
+SAMPLE=${SAMPLE:-}
+VIDEO_ID=${VIDEO_ID:-}
+POLL_TIMEOUT=${POLL_TIMEOUT:-240}
+POLL_INTERVAL=${POLL_INTERVAL:-3}
+EXPECTED_RENDITIONS=${EXPECTED_RENDITIONS:-3}
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+say()  { echo "[e2e] $*"; }
+fail() { echo "[e2e] FAIL: $*" >&2; exit 1; }
+need() { command -v "$1" >/dev/null 2>&1 || fail "missing dependency: $1"; }
+
+# http_get URL -> prints status code, writes body to $TMP/body
+http_get() { curl -s -o "$TMP/body" -w '%{http_code}' "$1"; }
+
+# resolve_url BASE_URL LINE -> absolute URL for a manifest/segment reference
+resolve_url() {
+  local base=$1 line=$2
+  case "$line" in
+    http://*|https://*) echo "$line" ;;
+    /*)                 echo "${VOD}${line}" ;;                       # absolute path
+    *)                  echo "${base%/*}/${line}" ;;                  # relative to manifest dir
+  esac
+}
+
+need curl
+need jq
+
+say "endpoints: auth=$AUTH upload=$UPLOAD metadata=$METADATA vod=$VOD"
+
+# ── 1. health ─────────────────────────────────────────────────────────────
+say "1) health"
+[ "$(http_get "$VOD/health")" = "200" ] || fail "nginx-vod not healthy at $VOD/health"
+say "   nginx-vod: ok"
+if [ -z "$VIDEO_ID" ]; then
+  for pair in "auth:$AUTH" "upload:$UPLOAD" "metadata:$METADATA"; do
+    name=${pair%%:*}; url=${pair#*:}
+    [ "$(http_get "$url/health")" = "200" ] || fail "$name not healthy at $url/health"
+    say "   $name: ok"
+  done
+fi
+
+# ── 2. auth + upload (skipped when VIDEO_ID is provided) ───────────────────
+if [ -z "$VIDEO_ID" ]; then
+  say "2) auth: register/login ($EMAIL)"
+  code=$(curl -s -o "$TMP/body" -w '%{http_code}' -X POST "$AUTH/api/v1/auth/register" \
+    -H 'Content-Type: application/json' -d "{\"email\":\"$EMAIL\",\"password\":\"$PASSWORD\"}")
+  if [ "$code" = "409" ]; then
+    code=$(curl -s -o "$TMP/body" -w '%{http_code}' -X POST "$AUTH/api/v1/auth/login" \
+      -H 'Content-Type: application/json' -d "{\"email\":\"$EMAIL\",\"password\":\"$PASSWORD\"}")
+  fi
+  [ "$code" = "200" ] || [ "$code" = "201" ] || fail "auth failed ($code): $(cat "$TMP/body")"
+  TOKEN=$(jq -r '.access_token' < "$TMP/body")
+  [ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] || fail "no access_token in auth response"
+  say "   token acquired"
+
+  if [ -z "$SAMPLE" ]; then
+    need ffmpeg
+    SAMPLE="$TMP/sample.mp4"
+    say "   generating 6s 1280x720 sample via ffmpeg"
+    ffmpeg -y -loglevel error \
+      -f lavfi -i "testsrc=size=1280x720:rate=30:duration=6" \
+      -f lavfi -i "sine=frequency=440:duration=6" \
+      -c:v libx264 -pix_fmt yuv420p -c:a aac -shortest "$SAMPLE" \
+      || fail "ffmpeg sample generation failed"
+  fi
+  [ -f "$SAMPLE" ] || fail "sample not found: $SAMPLE"
+
+  say "3) upload $SAMPLE"
+  code=$(curl -s -o "$TMP/body" -w '%{http_code}' -X POST "$UPLOAD/api/v1/videos/upload" \
+    -H "Authorization: Bearer $TOKEN" \
+    -F "file=@$SAMPLE;type=video/mp4" -F "title=e2e-sample")
+  [ "$code" = "201" ] || fail "upload failed ($code): $(cat "$TMP/body")"
+  VIDEO_ID=$(jq -r '.id' < "$TMP/body")
+  [ -n "$VIDEO_ID" ] && [ "$VIDEO_ID" != "null" ] || fail "no video id in upload response"
+  say "   video_id=$VIDEO_ID"
+
+  say "4) poll status (timeout ${POLL_TIMEOUT}s)"
+  deadline=$(( $(date +%s) + POLL_TIMEOUT ))
+  status=""
+  while :; do
+    [ "$(http_get "$METADATA/api/v1/videos/$VIDEO_ID")" = "200" ] || fail "metadata get failed"
+    status=$(jq -r '.status' < "$TMP/body")
+    say "   status=$status"
+    [ "$status" = "ready" ] && break
+    [ "$status" = "failed" ] && fail "transcode reported failed"
+    [ "$(date +%s)" -ge "$deadline" ] && fail "timed out waiting for ready (last=$status)"
+    sleep "$POLL_INTERVAL"
+  done
+else
+  say "2) VIDEO_ID provided ($VIDEO_ID) — skipping auth/upload/poll"
+fi
+
+# ── 5. HLS assertions (Phase 5 acceptance) ─────────────────────────────────
+MASTER_URL="$VOD/hls/$VIDEO_ID/master.m3u8"
+say "5) HLS master: $MASTER_URL"
+[ "$(http_get "$MASTER_URL")" = "200" ] || fail "master.m3u8 not 200: $(cat "$TMP/body")"
+cp "$TMP/body" "$TMP/master.m3u8"
+
+streams=$(grep -c '#EXT-X-STREAM-INF' "$TMP/master.m3u8" || true)
+say "   EXT-X-STREAM-INF count=$streams (want $EXPECTED_RENDITIONS)"
+[ "$streams" = "$EXPECTED_RENDITIONS" ] || fail "expected $EXPECTED_RENDITIONS renditions, got $streams"
+
+# first variant playlist = first non-comment line after a STREAM-INF tag
+variant=$(grep -A1 '#EXT-X-STREAM-INF' "$TMP/master.m3u8" | grep -vE '^(#|--)' | head -1 | tr -d '\r')
+[ -n "$variant" ] || fail "no variant playlist line in master"
+VARIANT_URL=$(resolve_url "$MASTER_URL" "$variant")
+say "   variant: $VARIANT_URL"
+[ "$(http_get "$VARIANT_URL")" = "200" ] || fail "variant playlist not 200"
+cp "$TMP/body" "$TMP/variant.m3u8"
+grep -q '#EXTINF' "$TMP/variant.m3u8" || fail "variant playlist has no #EXTINF segments"
+
+target=$(grep -oE '#EXT-X-TARGETDURATION:[0-9]+' "$TMP/variant.m3u8" | grep -oE '[0-9]+' | head -1 || true)
+say "   target segment duration=${target:-?}s (vod_segment_duration=2000ms → ~2s)"
+
+# first segment reference
+seg=$(grep -vE '^#' "$TMP/variant.m3u8" | grep -vE '^\s*$' | head -1 | tr -d '\r')
+[ -n "$seg" ] || fail "no segment reference in variant playlist"
+SEG_URL=$(resolve_url "$VARIANT_URL" "$seg")
+say "   segment: $SEG_URL"
+[ "$(http_get "$SEG_URL")" = "200" ] || fail "segment not 200"
+cp "$TMP/body" "$TMP/seg.bin"
+[ -s "$TMP/seg.bin" ] || fail "segment is empty"
+
+if command -v ffprobe >/dev/null 2>&1; then
+  # MPEG-TS lists the stream under [PROGRAM] and again as top-level [STREAM] — take the first non-empty line.
+  codec=$(ffprobe -v error -select_streams v:0 -show_entries stream=codec_name -of csv=p=0 "$TMP/seg.bin" 2>/dev/null | tr -d '\r' | awk 'NF{print; exit}' || true)
+  say "   ffprobe segment video codec=${codec:-unknown}"
+  [ "$codec" = "h264" ] || fail "segment does not decode as h264 (got '${codec:-none}')"
+else
+  say "   ffprobe not found — skipping segment decode check"
+fi
+
+say "PASS: video=$VIDEO_ID master has $streams renditions, segments serve & decode"

--- a/services/auth/Dockerfile
+++ b/services/auth/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:0.7-python3.11-bookworm-slim AS builder
+FROM ghcr.io/astral-sh/uv:0.7-python3.14-bookworm-slim AS builder
 WORKDIR /app
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 COPY pyproject.toml uv.lock* ./
@@ -8,7 +8,7 @@ COPY alembic.ini ./
 COPY migrations ./migrations
 RUN --mount=type=cache,target=/root/.cache/uv uv sync --frozen || uv sync
 
-FROM python:3.11-slim
+FROM python:3.14-slim
 WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /app/.venv /app/.venv

--- a/services/auth/README.md
+++ b/services/auth/README.md
@@ -20,7 +20,7 @@ curl http://localhost:8001/api/v1/auth/register -X POST -H "Content-Type: applic
 # Проверка (black + flake8 + mypy)
 make lint-py
 # Или детально:
-uv run --project services/auth black --check services/auth/src --target-version py311
+uv run --project services/auth black --check services/auth/src --target-version py314
 uv run --project services/auth flake8 services/auth/src
 uv run --project services/auth mypy services/auth/src
 uv run --project services/auth ruff check services/auth/src  # если установлен ruff
@@ -29,7 +29,7 @@ uv run --project services/auth ruff check services/auth/src  # если уста
 make fix-py        # ruff --fix + black
 make fmt-py        # только black
 uv run --project services/auth ruff check --select I --fix services/auth/src  # сортировка импортов
-uv run --project services/auth black services/auth/src --target-version py311
+uv run --project services/auth black services/auth/src --target-version py314
 ```
 
 ## Тесты

--- a/services/auth/pyproject.toml
+++ b/services/auth/pyproject.toml
@@ -2,7 +2,7 @@
 name = "flowix-auth"
 version = "0.1.0"
 description = "Flowix Auth Service — FastAPI + JWT"
-requires-python = ">=3.11"
+requires-python = ">=3.14"
 dependencies = [
   "fastapi>=0.115,<0.116",
   "uvicorn[standard]>=0.34,<0.35",
@@ -30,11 +30,11 @@ dev = [
 
 [tool.black]
 line-length = 100
-target-version = ["py311"]
+target-version = ["py314"]
 
 [tool.ruff]
 line-length = 100
-target-version = "py311"
+target-version = "py314"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "W"]
@@ -44,7 +44,7 @@ ignore = ["E501"]
 known-first-party = ["src"]
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.14"
 strict = false
 ignore_missing_imports = true
 disable_error_code = ["import-untyped", "import-not-found", "import"]

--- a/services/metadata/cmd/server/main.go
+++ b/services/metadata/cmd/server/main.go
@@ -86,6 +86,7 @@ func main() {
 	// internal (no auth)
 	r.Patch("/internal/videos/{id}/status", vh.UpdateStatus)
 	r.Get("/internal/videos/{id}", vh.GetInternal)
+	r.Get("/internal/videos/{id}/vod", vh.GetVODMapping)
 
 	log.Printf("metadata listening :%s", port)
 	if err := http.ListenAndServe(":"+port, r); err != nil {

--- a/services/metadata/internal/handler/video.go
+++ b/services/metadata/internal/handler/video.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"sort"
 	"strconv"
 
 	"flowix/metadata/internal/middleware"
@@ -42,6 +43,7 @@ func (h *VideoHandler) Register(r chi.Router) {
 	// internal (no auth) for transcoder/upload
 	r.Patch("/internal/videos/{id}/status", h.UpdateStatus)
 	r.Get("/internal/videos/{id}", h.GetInternal)
+	r.Get("/internal/videos/{id}/vod", h.GetVODMapping)
 }
 
 // Create godoc
@@ -102,6 +104,39 @@ func (h *VideoHandler) Get(w http.ResponseWriter, r *http.Request) {
 // @Router /internal/videos/{id} [get]
 func (h *VideoHandler) GetInternal(w http.ResponseWriter, r *http.Request) {
 	h.Get(w, r)
+}
+
+type vodMapping struct {
+	Sequences []vodSequence `json:"sequences"`
+}
+
+type vodSequence struct {
+	Clips []vodClip `json:"clips"`
+}
+
+type vodClip struct {
+	Type string `json:"type"`
+	Path string `json:"path"`
+}
+
+// GetVODMapping returns the nginx-vod mapped-mode representation for a ready video.
+func (h *VideoHandler) GetVODMapping(w http.ResponseWriter, r *http.Request) {
+	v, err := h.repo.GetByID(r.Context(), chi.URLParam(r, "id"))
+	if err != nil || v.Status != model.StatusReady || len(v.Renditions) != 3 {
+		writeError(w, r, http.StatusNotFound, "video not ready")
+		return
+	}
+
+	rends := append([]model.Rendition(nil), v.Renditions...)
+	sort.Slice(rends, func(i, j int) bool { return rends[i].Bitrate < rends[j].Bitrate })
+	mapping := vodMapping{Sequences: make([]vodSequence, 0, len(rends))}
+	for _, rendition := range rends {
+		mapping.Sequences = append(mapping.Sequences, vodSequence{Clips: []vodClip{{
+			Type: "source",
+			Path: "/" + rendition.S3Key,
+		}}})
+	}
+	writeJSON(w, r, http.StatusOK, mapping)
 }
 
 // List godoc

--- a/services/metadata/internal/handler/video_test.go
+++ b/services/metadata/internal/handler/video_test.go
@@ -115,6 +115,7 @@ func testRouter(store VideoStore) chi.Router {
 	r.Get("/api/v1/videos/{id}", vh.Get)
 	r.Patch("/internal/videos/{id}/status", vh.UpdateStatus)
 	r.Get("/internal/videos/{id}", vh.GetInternal)
+	r.Get("/internal/videos/{id}/vod", vh.GetVODMapping)
 	return r
 }
 
@@ -282,5 +283,30 @@ func TestUpdateStatusInternal(t *testing.T) {
 	}
 	if len(store.videos["vid-1"].Renditions) != 1 {
 		t.Fatalf("want renditions 1 got %d", len(store.videos["vid-1"].Renditions))
+	}
+}
+
+func TestGetVODMapping(t *testing.T) {
+	store := newFake()
+	store.videos["vid-1"] = &model.Video{
+		ID: "vid-1", Status: model.StatusReady,
+		Renditions: []model.Rendition{
+			{Quality: "1080p", Bitrate: 5000, S3Key: "renditions/vid-1/1080p.mp4"},
+			{Quality: "360p", Bitrate: 800, S3Key: "renditions/vid-1/360p.mp4"},
+			{Quality: "720p", Bitrate: 2500, S3Key: "renditions/vid-1/720p.mp4"},
+		},
+	}
+	r := testRouter(store)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/internal/videos/vid-1/vod", nil))
+	if w.Code != 200 {
+		t.Fatalf("want 200 got %d: %s", w.Code, w.Body.String())
+	}
+	var got vodMapping
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Sequences) != 3 || got.Sequences[0].Clips[0].Path != "/renditions/vid-1/360p.mp4" {
+		t.Fatalf("unexpected mapping: %+v", got)
 	}
 }

--- a/services/transcoder/Dockerfile
+++ b/services/transcoder/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:0.7-python3.11-bookworm-slim AS builder
+FROM ghcr.io/astral-sh/uv:0.7-python3.14-bookworm-slim AS builder
 WORKDIR /app
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 RUN apt-get update && apt-get install -y --no-install-recommends ffmpeg curl && rm -rf /var/lib/apt/lists/*
@@ -7,7 +7,7 @@ RUN --mount=type=cache,target=/root/.cache/uv uv sync --frozen --no-install-proj
 COPY app ./app
 RUN --mount=type=cache,target=/root/.cache/uv uv sync --frozen || uv sync
 
-FROM python:3.11-slim
+FROM python:3.14-slim
 WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends ffmpeg curl procps && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /app/.venv /app/.venv

--- a/services/transcoder/README.md
+++ b/services/transcoder/README.md
@@ -16,7 +16,7 @@ docker compose -f deploy/docker-compose.yml logs -f transcoder
 ## Линт / формат
 ```bash
 make lint-py  # проверяет и auth и transcoder
-uv run --project services/transcoder black --check services/transcoder/app --target-version py311
+uv run --project services/transcoder black --check services/transcoder/app --target-version py314
 uv run --project services/transcoder flake8 services/transcoder/app
 uv run --project services/transcoder mypy services/transcoder/app
 make fmt-py

--- a/services/transcoder/pyproject.toml
+++ b/services/transcoder/pyproject.toml
@@ -2,7 +2,7 @@
 name = "flowix-transcoder"
 version = "0.1.0"
 description = "Flowix Transcoding Worker — Celery + FFmpeg"
-requires-python = ">=3.11"
+requires-python = ">=3.14"
 dependencies = [
   "celery>=5.4,<6",
   "boto3>=1.35,<2",
@@ -25,11 +25,11 @@ dev = [
 
 [tool.black]
 line-length = 100
-target-version = ["py311"]
+target-version = ["py314"]
 
 [tool.ruff]
 line-length = 100
-target-version = "py311"
+target-version = "py314"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "W"]
@@ -39,7 +39,7 @@ ignore = ["E501"]
 known-first-party = ["app"]
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.14"
 strict = false
 ignore_missing_imports = true
 disable_error_code = ["import-untyped", "import-not-found"]

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -12,8 +12,16 @@ T4 cumulative pipeline — T1 → T1+T2 → T1+T2+T3 → T1+T2+T3+T4 без Dock
 """
 
 import json
+import sys
 import uuid
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
+
+ROOT = Path(__file__).resolve().parents[1]
+for _p in (ROOT / "services/auth", ROOT / "services/transcoder"):
+    _s = str(_p)
+    if _s not in sys.path:
+        sys.path.insert(0, _s)
 
 from fastapi.testclient import TestClient  # type: ignore[import-untyped]
 


### PR DESCRIPTION
## Description

Phase 5 — JIT HLS streaming via nginx-vod-module (`docs/PLAN.md`).

- `deploy/nginx/Dockerfile`: build `nginx:1.25.5-alpine` with `kaltura/nginx-vod-module` as a dynamic module; compose now builds this image instead of mounting a config into stock nginx.
- `deploy/nginx/nginx.conf`: `vod hls` in `vod_mode mapped` — mapping JSON comes from metadata (`vod_upstream_location /mapping`), MP4 renditions are fetched from MinIO over HTTP (`vod_remote_upstream_location /minio`). `vod_segment_duration 2000` + `vod_align_segments_to_key_frames on`.
- `services/metadata`: new internal endpoint `GET /internal/videos/{id}/vod` returns the nginx-vod mapping (3 sequences, ascending bitrate); 404 unless the video is `ready` with 3 renditions.
- `scripts/e2e.sh`: real end-to-end check replacing the placeholder — register/login → ffmpeg sample upload → poll until `ready` → assert HLS master/variant/segment. `VIDEO_ID=<id>` skips the upload and checks streaming alone.
- Housekeeping: bump auth/transcoder to Python 3.14, `pyrightconfig.json` for the out-of-root Python services, test `sys.path` roots, `CLAUDE.md`.

Acceptance verified on a live stack: `master.m3u8` returns 3 × `EXT-X-STREAM-INF`, the variant playlist (`index-f1-v1-a1.m3u8`) has `#EXTINF` with `TARGETDURATION:2`, and the first segment (`seg-1-f1-v1-a1.ts`) serves 200 and decodes as h264.

hls.js playback is Phase 7 (no frontend player yet); the gateway is still a stub, so `/hls/*` is served on `:8081` directly until Phase 6.

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor
- [x] test
- [x] chore

## Checklist

- [ ] `make lint-*` passes — `gofmt`/`go vet` clean on `services/metadata`; `make lint-py` not run locally
- [x] Tests added/updated — `TestGetVODMapping` in `services/metadata/internal/handler/video_test.go`, plus `scripts/e2e.sh`
- [x] Docs updated (if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
