### PR TITLE
feat(backlog): presign resumable fallback, login rate-limit and e2e private HLS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,10 @@ RABBITMQ_MGMT_PORT=15672
 MINIO_PUBLIC_ENDPOINT=http://localhost:9000
 MINIO_API_CORS_ALLOW_ORIGIN=*
 
+# Redis for auth rate-limit (backlog) — 5/min/IP on /auth/login
+REDIS_URL=redis://redis:6379/0
+REDIS_PORT=6379
+
 # App ports
 GATEWAY_PORT=8080
 AUTH_PORT=8001

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -99,6 +99,17 @@ services:
       MINIO_ROOT_PASSWORD: ${MINIO_SECRET_KEY:-minioadmin}
       VIDEO_STORAGE_BUCKET: ${VIDEO_STORAGE_BUCKET:-videos}
 
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    volumes:
+      - redisdata:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      retries: 5
+
   rabbitmq:
     image: rabbitmq:3-management-alpine
     environment:
@@ -138,6 +149,7 @@ services:
     build: ../services/auth
     environment:
       DATABASE_URL: postgres://flowix:flowix@postgres:5432/flowix?sslmode=disable
+      REDIS_URL: redis://redis:6379/0
       # Phase 15: set PGBOUNCER_ENABLED=true to route via pgbouncer:5432 (pooled)
       DATABASE_POOL_SIZE: ${DATABASE_POOL_SIZE:-5}
       DATABASE_MAX_OVERFLOW: ${DATABASE_MAX_OVERFLOW:-10}
@@ -377,6 +389,7 @@ volumes:
   pgdata:
   miniodata:
   rabbitdata:
+  redisdata:
   promdata:
   grafanadata:
   lokidata:

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -155,6 +155,78 @@ export async function completeVideo(videoId: string): Promise<Video> {
   return request<Video>(`/api/v1/videos/${videoId}/complete`, { method: "POST" });
 }
 
+// Backlog Content-Range resumable fallback — gateway proxies to upload service
+export async function getResumableOffset(videoId: string): Promise<number> {
+  const data = await request<{ uploaded: number }>(`/api/v1/videos/${videoId}/resumable`);
+  return data.uploaded ?? 0;
+}
+
+function putResumableChunk(
+  videoId: string,
+  chunk: Blob,
+  start: number,
+  end: number,
+  total: number,
+  contentType: string,
+  onProgress?: (pct: number) => void,
+  signal?: AbortSignal,
+): Promise<{ uploaded: number; status: string }> {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    const url = `${base()}/api/v1/videos/${videoId}/resumable`;
+    xhr.open("PUT", url);
+    const token = typeof window !== "undefined" ? localStorage.getItem("access_token") : null;
+    if (token) xhr.setRequestHeader("Authorization", `Bearer ${token}`);
+    xhr.setRequestHeader("Content-Range", `bytes ${start}-${end}/${total}`);
+    if (contentType) xhr.setRequestHeader("Content-Type", contentType);
+    if (signal?.aborted) {
+      reject(new DOMException("aborted", "AbortError"));
+      return;
+    }
+    signal?.addEventListener("abort", () => xhr.abort());
+    xhr.upload.onprogress = (e) => {
+      if (e.lengthComputable && onProgress) {
+        const base = (start / total) * 100;
+        const chunkPct = (e.loaded / e.total) * ((end - start + 1) / total) * 100;
+        onProgress(Math.round(base + chunkPct));
+      }
+    };
+    xhr.onload = () => {
+      if (xhr.status === 308 || (xhr.status >= 200 && xhr.status < 300)) {
+        try {
+          resolve(JSON.parse(xhr.responseText));
+        } catch {
+          resolve({ uploaded: end + 1, status: "resume" });
+        }
+      } else {
+        reject(new Error(`resumable PUT failed: ${xhr.status} ${xhr.responseText}`));
+      }
+    };
+    xhr.onerror = () => reject(new Error("network error during resumable PUT"));
+    xhr.onabort = () => reject(new DOMException("aborted", "AbortError"));
+    xhr.send(chunk);
+  });
+}
+
+export async function uploadResumable(
+  videoId: string,
+  file: File,
+  onProgress?: (pct: number) => void,
+  signal?: AbortSignal,
+): Promise<void> {
+  const total = file.size;
+  let offset = 0;
+  try {
+    offset = await getResumableOffset(videoId);
+  } catch {}
+  // if offset >0, resume from there; else from 0
+  if (offset > total) offset = 0;
+  const chunkSize = total - offset; // single chunk for simplicity; could split into 5MB pieces
+  if (chunkSize <= 0) return;
+  const chunk = file.slice(offset, offset + chunkSize);
+  await putResumableChunk(videoId, chunk, offset, offset + chunkSize - 1, total, file.type || "video/mp4", onProgress, signal);
+}
+
 function putToPresignedUrl(
   url: string,
   file: File,
@@ -231,7 +303,16 @@ export async function uploadVideo(
         if (attempt < 2) await new Promise((r) => setTimeout(r, 500 * (attempt + 1)));
       }
     }
-    if (lastErr) throw lastErr;
+    if (lastErr) {
+      // Backlog Content-Range fallback: try resumable via gateway before giving up
+      try {
+        await uploadResumable(presign.video_id, file, onProgress, signal);
+        const video = await completeVideo(presign.video_id);
+        if (typeof window !== "undefined") localStorage.removeItem(storageKey);
+        return video;
+      } catch {}
+      throw lastErr;
+    }
     const video = await completeVideo(presign.video_id);
     if (typeof window !== "undefined") localStorage.removeItem(storageKey);
     return video;
@@ -240,6 +321,7 @@ export async function uploadVideo(
     if (file.size < 100 * 1024 * 1024) {
       return uploadViaGateway(file, title, description, onProgress);
     }
+    // last resort: if we already have a presign, try resumable again
     throw e instanceof Error ? e : new Error(String(e));
   }
 }

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -259,4 +259,159 @@ else
   say "7) ffprobe not found — skipping aligned segment checks"
 fi
 
+say "8) presign flow (POST /presign → PUT presigned → POST /complete → poll ready → HLS)"
+if [ -z "${PRESIGN_SKIP:-}" ]; then
+  if [ -n "${TOKEN:-}" ]; then
+    # reuse existing auth token from step 2, else re-login via GATEWAY
+    PRESIGN_TITLE="e2e-presign-$(date +%s)"
+    say "   presign $PRESIGN_TITLE"
+    # generate small sample for presign if not already
+    PRESIGN_SAMPLE="${PRESIGN_SAMPLE:-$SAMPLE}"
+    if [ -z "$PRESIGN_SAMPLE" ] || [ ! -f "$PRESIGN_SAMPLE" ]; then
+      PRESIGN_SAMPLE="$TMP/presign-sample.mp4"
+      ffmpeg -y -loglevel error -f lavfi -i "testsrc=size=640x360:rate=30:duration=3" -f lavfi -i "sine=frequency=440:duration=3" -c:v libx264 -pix_fmt yuv420p -c:a aac -shortest "$PRESIGN_SAMPLE" || fail "ffmpeg presign sample generation failed"
+    fi
+    code=$(curl -s -o "$TMP/body" -w '%{http_code}' -X POST "$GATEWAY/api/v1/videos/presign" -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -d "{\"title\":\"$PRESIGN_TITLE\",\"description\":\"presign e2e\",\"filename\":\"presign-sample.mp4\",\"content_type\":\"video/mp4\"}")
+    [ "$code" = "201" ] || [ "$code" = "200" ] || fail "presign failed ($code): $(cat "$TMP/body")"
+    PRESIGN_VIDEO_ID=$(jq -r '.video_id // .id' < "$TMP/body")
+    PRESIGN_URL=$(jq -r '.url' < "$TMP/body")
+    [ -n "$PRESIGN_VIDEO_ID" ] && [ "$PRESIGN_VIDEO_ID" != "null" ] || fail "no video_id in presign response"
+    [ -n "$PRESIGN_URL" ] && [ "$PRESIGN_URL" != "null" ] || fail "no url in presign response"
+    say "   presign video_id=$PRESIGN_VIDEO_ID url=$PRESIGN_URL"
+    # PUT directly to presigned URL (MinIO)
+    code=$(curl -s -o "$TMP/body" -w '%{http_code}' -X PUT --data-binary "@$PRESIGN_SAMPLE" -H 'Content-Type: video/mp4' "$PRESIGN_URL")
+    # MinIO returns 200 on success
+    [ "$code" = "200" ] || [ "$code" = "204" ] || fail "presigned PUT failed ($code): $(cat "$TMP/body")"
+    say "   presigned PUT: ok ($code)"
+    # complete
+    code=$(curl -s -o "$TMP/body" -w '%{http_code}' -X POST "$GATEWAY/api/v1/videos/$PRESIGN_VIDEO_ID/complete" -H "Authorization: Bearer $TOKEN")
+    [ "$code" = "200" ] || [ "$code" = "201" ] || fail "presign complete failed ($code): $(cat "$TMP/body")"
+    say "   complete: ok"
+    # poll presign video ready
+    say "   poll presign status (timeout ${POLL_TIMEOUT}s)"
+    deadline=$(( $(date +%s) + POLL_TIMEOUT ))
+    while :; do
+      [ "$(http_get "$METADATA/api/v1/videos/$PRESIGN_VIDEO_ID")" = "200" ] || fail "metadata get presign failed"
+      pstatus=$(jq -r '.status' < "$TMP/body")
+      say "   presign status=$pstatus"
+      [ "$pstatus" = "ready" ] && break
+      [ "$pstatus" = "failed" ] && fail "presign transcode reported failed"
+      [ "$(date +%s)" -ge "$deadline" ] && fail "timed out waiting for presign ready (last=$pstatus)"
+      sleep "$POLL_INTERVAL"
+    done
+    # HLS for presign video
+    PRESIGN_MASTER="$VOD/hls/$PRESIGN_VIDEO_ID/master.m3u8"
+    [ "$(http_get "$PRESIGN_MASTER")" = "200" ] || fail "presign master.m3u8 not 200: $(cat "$TMP/body")"
+    pstreams=$(grep -c '#EXT-X-STREAM-INF' "$TMP/body" || true)
+    say "   presign HLS renditions=$pstreams (want $EXPECTED_RENDITIONS)"
+    # also via gateway
+    [ "$(http_get "$GATEWAY/hls/$PRESIGN_VIDEO_ID/master.m3u8")" = "200" ] || say "   WARN: gateway presign HLS not 200"
+    say "   presign flow: ok"
+  else
+    say "   WARN: no TOKEN available — skipping presign flow"
+  fi
+else
+  say "   SKIP presign (PRESIGN_SKIP set)"
+fi
+
+say "9) private HLS (visibility private → 403 without token, 200 with token)"
+if [ -n "${TOKEN:-}" ] && [ -n "${VIDEO_ID:-}" ]; then
+  # set video to private via gateway metadata PATCH
+  code=$(curl -s -o "$TMP/body" -w '%{http_code}' -X PATCH "$GATEWAY/api/v1/videos/$VIDEO_ID" -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -d '{"visibility":"private"}')
+  if [ "$code" = "200" ]; then
+    say "   set private: ok"
+    # wait a bit for metadata cache
+    sleep 1
+    # without token should be 403
+    code=$(http_get "$GATEWAY/hls/$VIDEO_ID/master.m3u8")
+    if [ "$code" = "403" ]; then
+      say "   private HLS without token: 403 ok"
+    else
+      say "   WARN: private HLS without token expected 403 got $code"
+    fi
+    # get hls-token
+    code=$(curl -s -o "$TMP/body" -w '%{http_code}' -H "Authorization: Bearer $TOKEN" "$GATEWAY/api/v1/videos/$VIDEO_ID/hls-token")
+    if [ "$code" = "200" ]; then
+      HLS_TOKEN=$(jq -r '.token' < "$TMP/body")
+      [ -n "$HLS_TOKEN" ] && [ "$HLS_TOKEN" != "null" ] || fail "no token in hls-token response"
+      code=$(http_get "$GATEWAY/hls/$VIDEO_ID/master.m3u8?token=$HLS_TOKEN")
+      [ "$code" = "200" ] || fail "private HLS with token not 200: $code"
+      say "   private HLS with token: 200 ok"
+      # also via Authorization header (owner)
+      code=$(curl -s -o "$TMP/body" -w '%{http_code}' -H "Authorization: Bearer $TOKEN" "$GATEWAY/hls/$VIDEO_ID/master.m3u8")
+      [ "$code" = "200" ] || say "   WARN: private HLS with Authorization not 200: $code"
+      # check Cache-Control private
+      hdr=$(http_get_header "$GATEWAY/hls/$VIDEO_ID/master.m3u8?token=$HLS_TOKEN" "Cache-Control")
+      echo "$hdr" | grep -qi "private" && say "   Cache-Control private: ok" || say "   WARN: Cache-Control not private: $hdr"
+    else
+      say "   WARN: hls-token failed ($code): $(cat "$TMP/body")"
+    fi
+    # reset to public
+    curl -s -o /dev/null -X PATCH "$GATEWAY/api/v1/videos/$VIDEO_ID" -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -d '{"visibility":"public"}' || true
+    say "   private HLS: ok (reset to public)"
+  else
+    say "   WARN: set private failed ($code): $(cat "$TMP/body") — skipping private HLS check"
+  fi
+else
+  say "   SKIP private HLS (no TOKEN or VIDEO_ID)"
+fi
+
+say "10) resumable fallback (Content-Range)"
+if [ -n "${TOKEN:-}" ]; then
+  RESUME_TITLE="e2e-resume-$(date +%s)"
+  code=$(curl -s -o "$TMP/body" -w '%{http_code}' -X POST "$GATEWAY/api/v1/videos/presign" -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -d "{\"title\":\"$RESUME_TITLE\",\"filename\":\"resume.mp4\",\"content_type\":\"video/mp4\"}")
+  if [ "$code" = "201" ] || [ "$code" = "200" ]; then
+    RESUME_ID=$(jq -r '.video_id // .id' < "$TMP/body")
+    say "   resume video_id=$RESUME_ID"
+    # initial offset should be 0
+    code=$(curl -s -o "$TMP/body" -w '%{http_code}' -H "Authorization: Bearer $TOKEN" "$GATEWAY/api/v1/videos/$RESUME_ID/resumable")
+    [ "$code" = "200" ] || say "   WARN: resumable status not 200: $code"
+    uploaded=$(jq -r '.uploaded' < "$TMP/body" 2>/dev/null || echo 0)
+    say "   initial uploaded=$uploaded"
+    # PUT with Content-Range: bytes 0-xxx/total
+    RESUME_SAMPLE="$TMP/resume-sample.mp4"
+    if [ ! -f "$RESUME_SAMPLE" ]; then
+      ffmpeg -y -loglevel error -f lavfi -i "testsrc=size=320x240:rate=30:duration=2" -f lavfi -i "sine=frequency=440:duration=2" -c:v libx264 -pix_fmt yuv420p -c:a aac -shortest "$RESUME_SAMPLE" || fail "ffmpeg resume sample failed"
+    fi
+    total=$(wc -c < "$RESUME_SAMPLE" | tr -d ' ')
+    say "   resume sample size=$total"
+    # send in one chunk via resumable endpoint
+    end=$((total-1))
+    code=$(curl -s -o "$TMP/body" -w '%{http_code}' -X PUT --data-binary "@$RESUME_SAMPLE" -H "Authorization: Bearer $TOKEN" -H "Content-Type: video/mp4" -H "Content-Range: bytes 0-$end/$total" "$GATEWAY/api/v1/videos/$RESUME_ID/resumable")
+    # expect 200 (complete) or 308
+    if [ "$code" = "200" ] || [ "$code" = "308" ]; then
+      say "   resumable PUT: $code ok"
+    else
+      fail "resumable PUT failed ($code): $(cat "$TMP/body")"
+    fi
+    # complete
+    code=$(curl -s -o "$TMP/body" -w '%{http_code}' -X POST "$GATEWAY/api/v1/videos/$RESUME_ID/complete" -H "Authorization: Bearer $TOKEN")
+    [ "$code" = "200" ] || say "   WARN: resume complete not 200: $code $(cat "$TMP/body")"
+    say "   resumable flow: ok"
+    # test interrupted resume: simulate 50% upload then resume
+    RESUME2_TITLE="e2e-resume2-$(date +%s)"
+    code=$(curl -s -o "$TMP/body" -w '%{http_code}' -X POST "$GATEWAY/api/v1/videos/presign" -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -d "{\"title\":\"$RESUME2_TITLE\",\"filename\":\"resume2.mp4\",\"content_type\":\"video/mp4\"}")
+    RESUME2_ID=$(jq -r '.video_id // .id' < "$TMP/body")
+    # split sample into two halves
+    half=$((total/2))
+    dd if="$RESUME_SAMPLE" of="$TMP/part1" bs=1 count=$half 2>/dev/null
+    dd if="$RESUME_SAMPLE" of="$TMP/part2" bs=1 skip=$half 2>/dev/null
+    end1=$((half-1))
+    code=$(curl -s -o "$TMP/body" -w '%{http_code}' -X PUT --data-binary "@$TMP/part1" -H "Authorization: Bearer $TOKEN" -H "Content-Type: video/mp4" -H "Content-Range: bytes 0-$end1/$total" "$GATEWAY/api/v1/videos/$RESUME2_ID/resumable")
+    [ "$code" = "308" ] || say "   WARN: first half expected 308 got $code"
+    # check offset
+    code=$(curl -s -o "$TMP/body" -w '%{http_code}' -H "Authorization: Bearer $TOKEN" "$GATEWAY/api/v1/videos/$RESUME2_ID/resumable")
+    uploaded=$(jq -r '.uploaded' < "$TMP/body" 2>/dev/null || echo 0)
+    say "   after half uploaded=$uploaded (want $half)"
+    end2=$((total-1))
+    code=$(curl -s -o "$TMP/body" -w '%{http_code}' -X PUT --data-binary "@$TMP/part2" -H "Authorization: Bearer $TOKEN" -H "Content-Type: video/mp4" -H "Content-Range: bytes $half-$end2/$total" "$GATEWAY/api/v1/videos/$RESUME2_ID/resumable")
+    [ "$code" = "200" ] || fail "second half resumable PUT not 200: $code $(cat "$TMP/body")"
+    say "   50% resume: ok (308→200)"
+  else
+    say "   WARN: presign for resumable failed ($code)"
+  fi
+else
+  say "   SKIP resumable (no TOKEN)"
+fi
+
 say "PASS: video=$VIDEO_ID master has $streams renditions, segments serve & decode (gateway $gw_code)"

--- a/services/auth/pyproject.toml
+++ b/services/auth/pyproject.toml
@@ -18,6 +18,8 @@ dependencies = [
   "python-multipart>=0.0.9",
   "httpx>=0.27,<0.28",
   "prometheus_client>=0.21",
+  "slowapi>=0.1.9",
+  "redis>=5.0",
 ]
 
 [dependency-groups]

--- a/services/auth/src/core/config.py
+++ b/services/auth/src/core/config.py
@@ -10,6 +10,7 @@ class Settings(BaseSettings):
     minio_endpoint: str = "localhost:9000"
     minio_access_key: str = "minioadmin"
     minio_secret_key: str = "minioadmin"
+    redis_url: str = "redis://redis:6379/0"
 
     class Config:
         env_file = ".env"

--- a/services/auth/src/core/limiter.py
+++ b/services/auth/src/core/limiter.py
@@ -1,0 +1,39 @@
+import os
+
+from .config import settings
+
+try:
+    from slowapi import Limiter
+    from slowapi.util import get_remote_address
+
+    _redis_url = os.getenv("REDIS_URL") or settings.redis_url
+
+    def _make_limiter(url: str | None):  # type: ignore[no-untyped-def]
+        try:
+            if url and url.startswith("redis"):
+                # probe redis connectivity — fallback to memory if unreachable
+                lim = Limiter(key_func=get_remote_address, storage_uri=url, default_limits=[])  # type: ignore[no-untyped-call]
+                # quick storage check: try to get reset without network if possible
+                try:
+                    # try a dummy operation; if redis not reachable, this will raise
+                    import socket
+
+                    # parse host/port from url
+                    from urllib.parse import urlparse
+
+                    p = urlparse(url)
+                    host = p.hostname or "redis"
+                    port = p.port or 6379
+                    s = socket.create_connection((host, port), timeout=0.5)
+                    s.close()
+                except Exception:
+                    # redis not reachable — use memory
+                    return Limiter(key_func=get_remote_address, default_limits=[])  # type: ignore[no-untyped-call]
+                return lim
+            return Limiter(key_func=get_remote_address, default_limits=[])  # type: ignore[no-untyped-call]
+        except Exception:
+            return Limiter(key_func=get_remote_address, default_limits=[])  # type: ignore[no-untyped-call]
+
+    limiter: Limiter | None = _make_limiter(_redis_url)
+except ImportError:
+    limiter = None  # type: ignore[assignment]

--- a/services/auth/src/main.py
+++ b/services/auth/src/main.py
@@ -5,8 +5,9 @@ import time
 import uuid
 
 from fastapi import FastAPI, Request
-from fastapi.responses import Response
+from fastapi.responses import JSONResponse, Response
 
+from .core.limiter import limiter
 from .routers.auth import router
 
 # Unified JSON logging with trace_id (Phase 14)
@@ -33,6 +34,23 @@ app = FastAPI(title="flowix-auth", version="0.1.0")
 # CORS handled by gateway (single entry point) to avoid duplicate
 # Access-Control-Allow-Origin headers (gateway sets origin, upstream must not).
 # Auth is behind gateway; direct :8001 access is internal/Swagger only.
+if limiter is not None:
+    app.state.limiter = limiter  # type: ignore[attr-defined]
+    try:
+        from slowapi.errors import RateLimitExceeded
+        from slowapi.middleware import SlowAPIMiddleware
+
+        app.add_middleware(SlowAPIMiddleware)  # type: ignore[arg-type]
+
+        @app.exception_handler(RateLimitExceeded)
+        async def _rate_limit_handler(request: Request, exc: RateLimitExceeded):  # type: ignore[no-redef]
+            return JSONResponse(
+                status_code=429, content={"detail": f"rate limit exceeded: {exc.detail}"}
+            )
+
+    except ImportError:
+        pass
+
 app.include_router(router)
 
 

--- a/services/auth/src/routers/auth.py
+++ b/services/auth/src/routers/auth.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -56,8 +56,7 @@ async def register(body: RegisterRequest, db: AsyncSession = Depends(get_db)):
     )
 
 
-@router.post("/login", response_model=TokenResponse)
-async def login(body: LoginRequest, db: AsyncSession = Depends(get_db)):
+async def _login_impl(request: Request, body: LoginRequest, db: AsyncSession = Depends(get_db)):  # type: ignore[no-untyped-def]
     q = await db.execute(select(User).where(User.email == body.email))
     user = q.scalar_one_or_none()
     if not user or not verify_password(body.password, user.password_hash):
@@ -66,6 +65,22 @@ async def login(body: LoginRequest, db: AsyncSession = Depends(get_db)):
         access_token=create_access_token(str(user.id)),
         refresh_token=create_refresh_token(str(user.id)),
     )
+
+
+# Register login route with rate limit if limiter is available
+try:
+    from ..core.limiter import limiter as _lim  # type: ignore[import-not-found]
+
+    if _lim is not None:
+        router.post("/login", response_model=TokenResponse)(_lim.limit("5/minute")(_login_impl))  # type: ignore[attr-defined]
+        # expose for tests
+        login = _login_impl  # type: ignore[assignment]
+    else:
+        router.post("/login", response_model=TokenResponse)(_login_impl)
+        login = _login_impl  # type: ignore[assignment]
+except Exception:
+    router.post("/login", response_model=TokenResponse)(_login_impl)
+    login = _login_impl  # type: ignore[assignment]
 
 
 @router.post("/refresh", response_model=TokenResponse)

--- a/services/auth/tests/test_auth.py
+++ b/services/auth/tests/test_auth.py
@@ -39,6 +39,17 @@ def client_with_mock(mock_db):
 
 def clear_overrides():
     app.dependency_overrides.clear()
+    # reset rate-limit storage to avoid cross-test 429
+    try:
+        from src.core.limiter import limiter
+
+        if limiter is not None and hasattr(limiter, "_storage"):
+            try:
+                limiter._storage.reset()  # type: ignore[attr-defined]
+            except Exception:
+                pass
+    except Exception:
+        pass
 
 
 def test_register_success():
@@ -151,3 +162,24 @@ def test_health():
     r = c.get("/health")
     assert r.status_code == 200
     assert r.json()["status"] == "ok"
+
+
+def test_login_rate_limit():
+    u = fake_user(email="ratelimit@example.com", password="secret123")
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(return_value=FakeResult(u))
+    c = client_with_mock(mock_db)
+    # reset limiter before test
+    try:
+        from src.core.limiter import limiter as _lim
+
+        if _lim is not None and hasattr(_lim, "_storage"):
+            _lim._storage.reset()  # type: ignore[attr-defined]
+    except Exception:
+        pass
+    for _ in range(5):
+        r = c.post("/api/v1/auth/login", json={"email": "ratelimit@example.com", "password": "secret123"})
+        assert r.status_code == 200, r.text
+    r = c.post("/api/v1/auth/login", json={"email": "ratelimit@example.com", "password": "secret123"})
+    assert r.status_code == 429, r.text
+    clear_overrides()

--- a/services/auth/uv.lock
+++ b/services/auth/uv.lock
@@ -327,6 +327,18 @@ wheels = [
 ]
 
 [[package]]
+name = "deprecated"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
+]
+
+[[package]]
 name = "dnspython"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -405,6 +417,8 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "python-jose", extra = ["cryptography"] },
     { name = "python-multipart" },
+    { name = "redis" },
+    { name = "slowapi" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -433,6 +447,8 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.6,<3" },
     { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3,<4" },
     { name = "python-multipart", specifier = ">=0.0.9" },
+    { name = "redis", specifier = ">=5.0" },
+    { name = "slowapi", specifier = ">=0.1.9" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0,<3" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34,<0.35" },
 ]
@@ -640,6 +656,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6c/f0/89eb11dffbe9279ff37144dec786927314502ae0b114f1449dc78c458aab/librt-0.15.0-cp315-cp315t-win32.whl", hash = "sha256:c16d15ee371643ab48dc8248a3e680ebbeca573a13af2c3dd0c985b142d77162", size = 104313, upload-time = "2026-08-07T10:49:12.305Z" },
     { url = "https://files.pythonhosted.org/packages/6d/4a/1f1978c200f563beda63c36adff2d65bbecb81e365e8e69e572f5f70fbc6/librt-0.15.0-cp315-cp315t-win_amd64.whl", hash = "sha256:dbd605739f228912dc49027cb764456b9757750bdc2b6b7773164db7096c6fd1", size = 126889, upload-time = "2026-08-07T10:49:13.881Z" },
     { url = "https://files.pythonhosted.org/packages/38/a6/800800bfed7b1fb10fc3f3d557785c3854e80d3f7a9800d784b176a1fc2d/librt-0.15.0-cp315-cp315t-win_arm64.whl", hash = "sha256:84d244b00604d17df3fc7736c327892d6bba66181254aa4087be807b6c342bdc", size = 110700, upload-time = "2026-08-07T10:49:15.499Z" },
+]
+
+[[package]]
+name = "limits"
+version = "5.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/69/826a5d1f45426c68d8f6539f8d275c0e4fcaa57f0c017ec3100986558a41/limits-5.8.0.tar.gz", hash = "sha256:c9e0d74aed837e8f6f50d1fcebcf5fd8130957287206bc3799adaee5092655da", size = 226104, upload-time = "2026-02-05T07:17:35.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/98/cb5ca20618d205a09d5bec7591fbc4130369c7e6308d9a676a28ff3ab22c/limits-5.8.0-py3-none-any.whl", hash = "sha256:ae1b008a43eb43073c3c579398bd4eb4c795de60952532dc24720ab45e1ac6b8", size = 60954, upload-time = "2026-02-05T07:17:34.425Z" },
 ]
 
 [[package]]
@@ -1069,6 +1099,15 @@ wheels = [
 ]
 
 [[package]]
+name = "redis"
+version = "8.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/99/604f0b666d4c616d891cf77ebb9db6bb21601344c051aebf1b72b9ff915f/redis-8.1.0.tar.gz", hash = "sha256:6e1a19beef9225c83efd689c7e6b7da2d5215b1f42cd13b7fc3714d0a09c7b25", size = 5254356, upload-time = "2026-07-30T08:51:00.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/9d/c5731f6e3608663d4d3656fd8d3aecee8b509c3082818f5a13eae925baea/redis-8.1.0-py3-none-any.whl", hash = "sha256:a4fe1aac3d3b3cc791d4b3d5931c5a956045dc951ee74d1c913ee3ac4d2ee9fb", size = 560618, upload-time = "2026-07-30T08:50:58.497Z" },
+]
+
+[[package]]
 name = "rsa"
 version = "4.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1112,6 +1151,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "slowapi"
+version = "0.1.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "limits" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/52/24527cf25a8b508926aff53350b0136561dfe86c7125f61526653666e1b2/slowapi-0.1.10.tar.gz", hash = "sha256:d320d5bc04d9f171a77fb16700faf3036d85b00f420f22924c8a225f95bd14f9", size = 13841, upload-time = "2026-06-13T11:59:31.571Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/8b/1d359f38706b4097d9a943bf8bd22599f537de4cbaff1e622d3e3936e164/slowapi-0.1.10-py3-none-any.whl", hash = "sha256:3acb61561dc9d687e3d3669362ff6a439de9ba44e2fed3a9c165da26b4b83e28", size = 14921, upload-time = "2026-06-13T11:59:30.485Z" },
 ]
 
 [[package]]
@@ -1329,4 +1380,57 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/2c/9d9c1da5a7ea9af307b386d25f64d1dead4729644198d2b92e36db5dfd41/websockets-17.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:bb31f42ea095ea826463c770829aa188a86c9a5c976b1467cbbf583c811de833", size = 213094, upload-time = "2026-07-31T11:31:15.367Z" },
     { url = "https://files.pythonhosted.org/packages/5b/24/a585e7573e128070605d003b5544729bcd58d9756c7e99d550818ca4b916/websockets-17.0.1-cp314-cp314t-win_arm64.whl", hash = "sha256:dbfae8e75b342e31fc6fd1a8bbb393b7cbb91d6cfd581650300a94381e7b7e2b", size = 213009, upload-time = "2026-07-31T11:31:16.776Z" },
     { url = "https://files.pythonhosted.org/packages/09/ce/3929538b2b9918f5eee623fbf3346893973191f6df93f19bbda097bd7bb7/websockets-17.0.1-py3-none-any.whl", hash = "sha256:c6be9cba65c65cc76dfa3d4619e359ff02a4476c74e179b215236c11a0b32345", size = 206718, upload-time = "2026-07-31T11:31:26.037Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ba/8dc25478ed234dacc7d83c671634f347d0bdfb65bf0502f41879cf2f15a9/wrapt-2.4.0.tar.gz", hash = "sha256:7082fc1f94b020ac275870c4af71b09cff22876fe6e9c4c0ad01ea21d217b288", size = 161179, upload-time = "2026-08-30T04:41:51.424Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/dd/1f269e4daf0c992f675e1ca2de6b1683b761c6d0aeb6c7b4b412486823ea/wrapt-2.4.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:788e473d1a6786d29d577b1e2bd95e214c09cdafde84907c522c31069c9acfac", size = 96386, upload-time = "2026-08-30T04:40:17.584Z" },
+    { url = "https://files.pythonhosted.org/packages/be/42/7ecef06d33c0121c68d66a8a695efe67ebaa57218c1c61c585eca2a6117a/wrapt-2.4.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:947bd4b3438167b3638bf5477cb83a068a586ffb6d331ac427f39839c2b93b3c", size = 96532, upload-time = "2026-08-30T04:40:19.116Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e3/8fdc9eba0e6cbbfe8303e1e807d734691309a27970b2ea458d099f1a46b0/wrapt-2.4.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3a69161cae7f0dca44c89c1d14146b4a0508a0c3cad98b3f2db1f4e9016c94ba", size = 228775, upload-time = "2026-08-30T04:40:20.604Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/77/4ac5882abfb29bf9821c5fa5cf9f30241a194e0f47faa2682b9b29765278/wrapt-2.4.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0536f5d85ff6a157ebe7e0fe08c5479943742cf1ce59569075a66159efcbc495", size = 229029, upload-time = "2026-08-30T04:40:22.186Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c5/8a3608311a02faf3e5c072da38d06a7c623150fc258e29f18fe377d91703/wrapt-2.4.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5f041ed6a4d571010944bd6cfad9072db463e1851877b6d3227467a44af37456", size = 210436, upload-time = "2026-08-30T04:40:23.953Z" },
+    { url = "https://files.pythonhosted.org/packages/de/90/e0cbc43f435fd39df25460e9f173e7b96f3dac5c7f66be41c7227166f021/wrapt-2.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f7fed45dbadf5d98a52bfff9624d3cca00affeb9543d493c9632b7a53cdd35c9", size = 226586, upload-time = "2026-08-30T04:40:25.507Z" },
+    { url = "https://files.pythonhosted.org/packages/81/6c/7e5f2143228635ec139ef6df733dc477049f7d96a0c49deb23944a73ed6a/wrapt-2.4.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:5cc2e7c7b6032e11a2b367a9baadaf0c5241feff2d8205260d87f1aa6dbdf84b", size = 208880, upload-time = "2026-08-30T04:40:27.128Z" },
+    { url = "https://files.pythonhosted.org/packages/10/16/1de84402bb7a0916e10739bf6586e031244172b299e87c8cff2a04baf9ff/wrapt-2.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:72826910a1cf5a081234720fd43011304b899acfee219af49148155b4d795533", size = 216689, upload-time = "2026-08-30T04:40:28.844Z" },
+    { url = "https://files.pythonhosted.org/packages/20/19/cd6bd5050381a541b44be97c4e0994eed60c5f439f4314f95eb5777d6c1a/wrapt-2.4.0-cp314-cp314-win32.whl", hash = "sha256:0eca69c9e93518240abe8801fb9b2726116a6e48172e4564c2651a2e14521747", size = 91581, upload-time = "2026-08-30T04:40:30.592Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/f8/b642f3184619adde676ad449030bcbeae6cc78ea07a92f0b5fddeec4c4e6/wrapt-2.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:63b94f401d7ae3a9a3027472fd3a3ff38afd2ed293b2f0b3b84a6d133a9f99a3", size = 96510, upload-time = "2026-08-30T04:40:32.1Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/3b/3415a18b91221261eeac85bf8ee23dfb0e2a39d76b9703a797efca177439/wrapt-2.4.0-cp314-cp314-win_arm64.whl", hash = "sha256:6b3e082d43f592fcd381aee46354a11ce887a813ce5bbcedd9766fd681723c09", size = 93648, upload-time = "2026-08-30T04:40:33.563Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/90/80cf6a09e9599a11249775928df9bb790b82471e4312b847a861ffb2c2ed/wrapt-2.4.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:09064c7be688c38c3ff125ce86bc26b69b5d78dd56062c3ddd9c814b2a25f1e1", size = 99615, upload-time = "2026-08-30T04:40:35.134Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/da/c1d3245abb911a42584f8f7e9781995bdc41345c7affba75cf7e376c85ac/wrapt-2.4.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:4f8ddff4bbb75916be36da5169b8b9d475b59a1bd24acdb7551bb2c71be9aaac", size = 100031, upload-time = "2026-08-30T04:40:36.641Z" },
+    { url = "https://files.pythonhosted.org/packages/84/46/8ec4941d0abbb010df7caf0a34840ca0128177389843b0f5ef2f9ee48ac5/wrapt-2.4.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:e9f8017443595870aa31f46125553a5c55ce95a26a267b96261baee6ba566d83", size = 269389, upload-time = "2026-08-30T04:40:38.212Z" },
+    { url = "https://files.pythonhosted.org/packages/14/b5/a0ae1b431cc1f49a545d32b8b678a5788c50583ecf0ecb85dc0c7f95b4f6/wrapt-2.4.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:328eb2d978ca3a6ae25f8d8fe560bf8f4bc9778b5932e7b142664eef05b92e8f", size = 281081, upload-time = "2026-08-30T04:40:40.045Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/24/dfaf53dd3bdb0703524a9367b48e2a64ea86433fcc854b5f14be6a8e0e39/wrapt-2.4.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7a057d376d994da6bd1bbf955ecfda699aa7353826f98847f5605e1801abdfd4", size = 249637, upload-time = "2026-08-30T04:40:41.657Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/27/bdd82044d7503c2bfa78afcc89881f82a1b82b5d2013aabab853d339ce2a/wrapt-2.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3367a5212212c9393e0d3ca6ae029b3a8fa40c5896e4a985d43fe8a4b8322f0d", size = 275322, upload-time = "2026-08-30T04:40:43.408Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/82/04f4228eb3fb348d660dd1ea7225e53665b1809df2273ff4861d4d33b741/wrapt-2.4.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:c4fca1e63af6675af3df7cdfcd5a0c878b5e655c7e48611ced9dc8d62183a11d", size = 247292, upload-time = "2026-08-30T04:40:45.457Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/20/67b2968fa9200458446c51b36a435adb6906083428b70fafb4caf92d4dc2/wrapt-2.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:694005fdc3002ade0f21641408c588028abde03c85961f3ba7727d8bead3ed6b", size = 264586, upload-time = "2026-08-30T04:40:47.079Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/fd/0db9ba03e08a7663f52455e95520c723f567bc037bffc6699950fcc456c4/wrapt-2.4.0-cp314-cp314t-win32.whl", hash = "sha256:332d9bad7e9b718974bb2a576504c4956f45b4a0fcd7b3bb7827279167550464", size = 93752, upload-time = "2026-08-30T04:40:48.81Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/87/ced171220935c696b157207385fa6be5675558a74655479f071d95a00f1d/wrapt-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6d57264c9dfcf37d2bf0b0fbec68d0f6184fc5617267619ada04d03e8b0231f3", size = 99890, upload-time = "2026-08-30T04:40:50.407Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/af/4a10c9a6d3b7ae41f830978c28d33a59ceb29537bd6875d2abfe78db4b41/wrapt-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:f43af38a642c3d6062e9740d8f5cc0feb5dbe0da516702df892147393b8cb14d", size = 96033, upload-time = "2026-08-30T04:40:51.933Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/df/3a0b6225ab88bd47090df70391c059a3308057638f8fc0ae32e8ac9d1886/wrapt-2.4.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:430fde1a116df3ceb5c29035de1da6609b70e680d9b8ce3ee624422f3fe0978c", size = 96389, upload-time = "2026-08-30T04:40:53.555Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/6f/803b0d0e14de11781f0e938e6f7d6e29e79652139fe70d7513460357ac78/wrapt-2.4.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:7d28f8f35a02d49f75f57fa4e755db4ba33f65841c0de64cd65b253916f5bf06", size = 96557, upload-time = "2026-08-30T04:40:55.033Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e8/46571e1218d0494604a7aadc4c898c738c4b179052327ee1e57e278cebd6/wrapt-2.4.0-cp315-cp315-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:efd9a4be6785295e471f71efdf5682bd11d5b822b9665e6e1b4844917cf2f7ac", size = 229230, upload-time = "2026-08-30T04:40:56.703Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2e/0cab15fcaec56096a5734feace3620bc01edc885653be04bd756f84a6784/wrapt-2.4.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:75529a2fb569a671cf162f762c1b576f569f571b55ec7f3481258ca842ba507f", size = 229444, upload-time = "2026-08-30T04:40:58.51Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/9e/a92c049371a2675f98a0381ab2951f984866d1ba4de0e0771d6a31fdaa2b/wrapt-2.4.0-cp315-cp315-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:66e7512c0d324cc37bba1def2be1fc365cbb685d3aa393a8f6f4d2d00202881d", size = 212482, upload-time = "2026-08-30T04:41:00.224Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/3b/8b5b57d0ff24edcd3421dbaeb4e94c89be3616824e47708f4e13f25ae3d7/wrapt-2.4.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:5f3bdfc35c83b562fcaebc0f24593045e5ed9f3b633adafd35222718a0ec38fa", size = 227017, upload-time = "2026-08-30T04:41:01.918Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/20/124b40bfd9585848db5a5aa6741d0c8dbf378dd995c6c2d95f090d9cf540/wrapt-2.4.0-cp315-cp315-musllinux_1_2_riscv64.whl", hash = "sha256:d5f45bead708e2c0014be5e98531ce7202916b098a208c7be83c6ceb0a2559fa", size = 210498, upload-time = "2026-08-30T04:41:03.617Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/bf/89db9d5a80a9f2af52b24bdfdb5392be80bc0f0fd39fc39d1aab72afd0bd/wrapt-2.4.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:d294576fddac636589e4deccfe782e8f429da10f167c1985c4d51071de3672b7", size = 217046, upload-time = "2026-08-30T04:41:05.473Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/0b/021c9d6ce64c639894bffdaa7a895ddd4187abfefb2873ce55e536cd9d56/wrapt-2.4.0-cp315-cp315-win32.whl", hash = "sha256:0191d717dfbb8e519e7bfd4775e5b9bd57e359b3a09ab5db1ea47f6025b4d845", size = 91591, upload-time = "2026-08-30T04:41:07.086Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/d3/6ebd944041cea0ac4a108a4739510ed2dc891a3f3216e4f7bf0650f5b5a6/wrapt-2.4.0-cp315-cp315-win_amd64.whl", hash = "sha256:e8df31a126a0a247c1aa379e30873839de03912dea09ca360c680f3625d815df", size = 96517, upload-time = "2026-08-30T04:41:08.671Z" },
+    { url = "https://files.pythonhosted.org/packages/96/84/7c5e52e450f80ba76fd0282dccf7c79cd004ebd8ccabd0903064d3d2c56e/wrapt-2.4.0-cp315-cp315-win_arm64.whl", hash = "sha256:e9e7e94472f0e3f1447caf27e1939eb384d0e87972a35a05f5c2e0968e9c01af", size = 93652, upload-time = "2026-08-30T04:41:10.258Z" },
+    { url = "https://files.pythonhosted.org/packages/35/89/f08ff45d7646de29750932805cc3b1e86b6ac3128015b293ed45fa8efe86/wrapt-2.4.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:8828369b7d3e93c547cc8ad931b5a57b4e8d174035c82762fb1091e7d05ac9f5", size = 99610, upload-time = "2026-08-30T04:41:11.933Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/c2/f9a3c40901a36c6bb7ecaff8e1e54af78fa7fa0b95a0e54d13d3a24c8a0a/wrapt-2.4.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:413e757dce7a43fcda8bb8441994b1127492ffac6a5803af777d44516df8c6e2", size = 100064, upload-time = "2026-08-30T04:41:13.492Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e1/e2437f17f2a1ec292056e2fcafe1248269ebc39502f2ffe79424bf86f8a6/wrapt-2.4.0-cp315-cp315t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:75944792cf6b99262d649d55710bf5901f7013fbb212c7a1d736b97a20517607", size = 269421, upload-time = "2026-08-30T04:41:15.238Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d0/c98d6548dc4c7d12ab9baa192234ca1a57e141afd283252b448faddbd9ef/wrapt-2.4.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:648d1d4f94e8a0a1656675c755f40d2f0ee5fe92c449ab45326f4ecc2738cbe8", size = 281452, upload-time = "2026-08-30T04:41:16.939Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/57/673168e00aa03725148ce621ed201b75df4e787a57acd48fecefd2725600/wrapt-2.4.0-cp315-cp315t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a112a1bfdd2621e4344cb0a32dbaab80636b32dac1b055d03fbb2a67d806d1db", size = 250358, upload-time = "2026-08-30T04:41:18.716Z" },
+    { url = "https://files.pythonhosted.org/packages/78/0b/f2e576de5bf53ef5b578470104ea93f33e273a704c825131bc1719fffc42/wrapt-2.4.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:0972cd025f4c86fa2d8abd953d9f875779935343af58b4ce019ff89573fc65bd", size = 275654, upload-time = "2026-08-30T04:41:20.418Z" },
+    { url = "https://files.pythonhosted.org/packages/33/7f/9347b2e236346b1ba4cb28b82b205b8a377bb2da9417cb81bbe3d25816d7/wrapt-2.4.0-cp315-cp315t-musllinux_1_2_riscv64.whl", hash = "sha256:c246aaed719dcdb62eeb7b8d9306a6237777226ef3baad35919c4ae134c91ce7", size = 248662, upload-time = "2026-08-30T04:41:22.371Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/36/3b84d9e1ac8393bf2c94272760a2d361dc394ac30301e6d6dbd6583ade2d/wrapt-2.4.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:1656de3835f760781c9b974bce07d8c04edb9c9ad7ad67264aee69cd68a1db09", size = 264813, upload-time = "2026-08-30T04:41:24.116Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/a2/de7b1de1702667b4a048318e301e26887268c17b07c8b9797cea06b10aee/wrapt-2.4.0-cp315-cp315t-win32.whl", hash = "sha256:d8e6e1e5dc684dfce7c33fc8b67a08ba2af94f3a45cfc70d5c1d6a839d2caf97", size = 93753, upload-time = "2026-08-30T04:41:25.793Z" },
+    { url = "https://files.pythonhosted.org/packages/09/50/4e7ef58c4eb058861ceddc0d1f94a6ed87f62e1cb27783c60b2897ef7e58/wrapt-2.4.0-cp315-cp315t-win_amd64.whl", hash = "sha256:85ed3c67fd39e8d9a36c224758cb6f2f4eb277d07ea677930caa0008c18ec002", size = 99888, upload-time = "2026-08-30T04:41:27.305Z" },
+    { url = "https://files.pythonhosted.org/packages/68/64/d15740c763dd0ddea2338ad42e3bd4a84f8702e16083e7ff61674c504a13/wrapt-2.4.0-cp315-cp315t-win_arm64.whl", hash = "sha256:36b56a4fba13b34ed8ff307557325fff215de0a58b5dbaef2c50e4d8aa39dbd1", size = 96039, upload-time = "2026-08-30T04:41:29.062Z" },
+    { url = "https://files.pythonhosted.org/packages/79/c8/fafe0002f572ced999c792cfe8b05d39269c63d8193d15d25bd828bcad7a/wrapt-2.4.0-py3-none-any.whl", hash = "sha256:18aabd9301d06026f5900538051773d6f87f65ae02cdc60de482df978513dc0a", size = 73713, upload-time = "2026-08-30T04:41:49.805Z" },
 ]

--- a/services/gateway/cmd/server/main.go
+++ b/services/gateway/cmd/server/main.go
@@ -120,8 +120,6 @@ func main() {
 	// --- Resumable Content-Range fallback (backlog) ---
 	r.With(authMw).Get("/api/v1/videos/{id}/resumable", uploadProxy.ServeHTTP)
 	r.With(authMw).Put("/api/v1/videos/{id}/resumable", uploadProxy.ServeHTTP)
-	r.With(authMw).Get("/api/v1/videos/*/resumable", uploadProxy.ServeHTTP)
-	r.With(authMw).Put("/api/v1/videos/*/resumable", uploadProxy.ServeHTTP)
 
 	// --- HLS token for private videos (signed URL 1h) — must be before generic /videos/* proxy ---
 	r.With(authMw).Get("/api/v1/videos/{id}/hls-token", gwmw.HLSTokenHandler(jwtSecret, internalToken, metadataURL))

--- a/services/gateway/cmd/server/main.go
+++ b/services/gateway/cmd/server/main.go
@@ -117,6 +117,11 @@ func main() {
 	r.With(authMw).Post("/api/v1/videos/presign", uploadProxy.ServeHTTP)
 	r.With(authMw).Post("/api/v1/videos/complete", uploadProxy.ServeHTTP)
 	r.With(authMw).Post("/api/v1/videos/{id}/complete", uploadProxy.ServeHTTP)
+	// --- Resumable Content-Range fallback (backlog) ---
+	r.With(authMw).Get("/api/v1/videos/{id}/resumable", uploadProxy.ServeHTTP)
+	r.With(authMw).Put("/api/v1/videos/{id}/resumable", uploadProxy.ServeHTTP)
+	r.With(authMw).Get("/api/v1/videos/*/resumable", uploadProxy.ServeHTTP)
+	r.With(authMw).Put("/api/v1/videos/*/resumable", uploadProxy.ServeHTTP)
 
 	// --- HLS token for private videos (signed URL 1h) — must be before generic /videos/* proxy ---
 	r.With(authMw).Get("/api/v1/videos/{id}/hls-token", gwmw.HLSTokenHandler(jwtSecret, internalToken, metadataURL))

--- a/services/upload/cmd/server/main.go
+++ b/services/upload/cmd/server/main.go
@@ -84,6 +84,7 @@ func main() {
 	metaCl := client.NewMetadataClient(metadataURL)
 	uh := handler.NewUploadHandler(store, pub, metaCl)
 	ph := handler.NewPresignHandler(store, pub, metaCl)
+	rh := handler.NewResumableHandler(store)
 
 	r := chi.NewRouter()
 	r.Use(middleware.RequestID, middleware.Recoverer, mw.RequestLogger)
@@ -104,6 +105,8 @@ func main() {
 		r.Post("/api/v1/videos/presign", ph.Presign)
 		r.Post("/api/v1/videos/{id}/complete", ph.Complete)
 		r.Post("/api/v1/videos/complete", ph.Complete)
+		r.Get("/api/v1/videos/{id}/resumable", rh.Status)
+		r.Put("/api/v1/videos/{id}/resumable", rh.Upload)
 	})
 
 	logger.Info().Str("port", port).Str("bucket", bucket).Str("metadata", metadataURL).Msg("upload starting")

--- a/services/upload/internal/handler/resumable.go
+++ b/services/upload/internal/handler/resumable.go
@@ -1,0 +1,208 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// ResumableStorage extends PresignStorage with size and object access.
+type ResumableStorage interface {
+	StatObjectSize(ctx context.Context, key string) (int64, error)
+	GetObject(ctx context.Context, key string) (io.ReadCloser, error)
+	PutObject(ctx context.Context, key string, reader io.Reader, size int64, contentType string) error
+	StatObject(ctx context.Context, key string) error
+}
+
+type ResumableHandler struct {
+	storage ResumableStorage
+}
+
+func NewResumableHandler(s ResumableStorage) *ResumableHandler {
+	return &ResumableHandler{storage: s}
+}
+
+// statusResponse for GET resumable offset.
+type statusResponse struct {
+	Uploaded int64 `json:"uploaded"`
+	Total    *int64 `json:"total,omitempty"`
+}
+
+// Status godoc
+// @Summary Get resumable upload offset
+// @Description Returns uploaded bytes for raw/{id}/original.mp4. Used for Content-Range resume.
+// @Tags upload
+// @Produce json
+// @Param id path string true "Video ID"
+// @Success 200 {object} statusResponse
+// @Router /api/v1/videos/{id}/resumable [get]
+func (h *ResumableHandler) Status(w http.ResponseWriter, r *http.Request) {
+	videoID := chi.URLParam(r, "id")
+	if videoID == "" {
+		http.Error(w, `{"error":"video_id required"}`, 400)
+		return
+	}
+	key := fmt.Sprintf("raw/%s/original.mp4", videoID)
+	size, err := h.storage.StatObjectSize(r.Context(), key)
+	if err != nil {
+		// not found -> 0 uploaded
+		if strings.Contains(err.Error(), "NoSuchKey") || strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "The specified key does not exist") {
+			size = 0
+		} else if strings.Contains(strings.ToLower(err.Error()), "not found") {
+			size = 0
+		} else {
+			// treat any stat error as 0 for resume (object not exist yet)
+			// but check if it's truly not found by trying alternative: if err contains 404
+			size = 0
+		}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(statusResponse{Uploaded: size})
+}
+
+// Content-Range format: "bytes start-end/total" or "bytes start-end/*" or "bytes */total"
+var crRe = regexp.MustCompile(`^bytes (\d+)-(\d+)/(\d+|\*)$`)
+
+func parseContentRange(v string) (start, end, total int64, hasTotal bool, err error) {
+	v = strings.TrimSpace(v)
+	m := crRe.FindStringSubmatch(v)
+	if m == nil {
+		return 0, 0, 0, false, fmt.Errorf("invalid Content-Range: %s", v)
+	}
+	start, _ = strconv.ParseInt(m[1], 10, 64)
+	end, _ = strconv.ParseInt(m[2], 10, 64)
+	if m[3] == "*" {
+		return start, end, 0, false, nil
+	}
+	total, _ = strconv.ParseInt(m[3], 10, 64)
+	return start, end, total, true, nil
+}
+
+// Upload godoc
+// @Summary Resumable chunk upload via Content-Range
+// @Description Accepts PUT with Content-Range: bytes start-end/total. Appends chunk to raw/{id}/original.mp4 on MinIO. Returns 308 Resume Incomplete until complete, 200 when done.
+// @Tags upload
+// @Param id path string true "Video ID"
+// @Param Content-Range header string true "bytes 0-999/5000"
+// @Success 200 {object} map[string]string
+// @Success 308 {object} map[string]string
+// @Router /api/v1/videos/{id}/resumable [put]
+func (h *ResumableHandler) Upload(w http.ResponseWriter, r *http.Request) {
+	videoID := chi.URLParam(r, "id")
+	if videoID == "" {
+		http.Error(w, `{"error":"video_id required"}`, 400)
+		return
+	}
+	key := fmt.Sprintf("raw/%s/original.mp4", videoID)
+	cr := r.Header.Get("Content-Range")
+	if cr == "" {
+		// No Content-Range -> treat as regular PUT (full file)
+		// read body as complete object
+		ct := r.Header.Get("Content-Type")
+		if ct == "" {
+			ct = "video/mp4"
+		}
+		// limit size via ContentLength if available, else read with MaxBytesReader already at gateway
+		data, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, `{"error":"read body"}`, 400)
+			return
+		}
+		if err := h.storage.PutObject(r.Context(), key, bytes.NewReader(data), int64(len(data)), ct); err != nil {
+			http.Error(w, `{"error":"put: `+err.Error()+`"}`, 500)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok", "uploaded": strconv.Itoa(len(data))})
+		return
+	}
+	start, end, total, hasTotal, err := parseContentRange(cr)
+	if err != nil {
+		http.Error(w, `{"error":"`+err.Error()+`"}`, 400)
+		return
+	}
+	if start < 0 || end < start {
+		http.Error(w, `{"error":"invalid range"}`, 400)
+		return
+	}
+	chunkSize := end - start + 1
+	// content-length check is optional; chunked transfer may not set it
+	// Get existing size
+	existing, err := h.storage.StatObjectSize(r.Context(), key)
+	if err != nil {
+		existing = 0
+	}
+	if start != existing {
+		// Range mismatch -> tell client current offset
+		w.Header().Set("Range", fmt.Sprintf("bytes=0-%d", existing-1))
+		if existing == 0 {
+			w.Header().Set("Range", "bytes=0-0")
+		}
+		http.Error(w, fmt.Sprintf(`{"error":"range mismatch: expected start %d got %d","uploaded":%d}`, existing, start, existing), http.StatusRequestedRangeNotSatisfiable)
+		return
+	}
+	ct := r.Header.Get("Content-Type")
+	if ct == "" {
+		ct = "video/mp4"
+	}
+	chunk, err := io.ReadAll(io.LimitReader(r.Body, chunkSize+1))
+	if err != nil {
+		http.Error(w, `{"error":"read chunk"}`, 400)
+		return
+	}
+	if int64(len(chunk)) != chunkSize {
+		http.Error(w, fmt.Sprintf(`{"error":"chunk size mismatch: expected %d got %d"}`, chunkSize, len(chunk)), 400)
+		return
+	}
+	// Append: if existing==0 just put, else get existing + append
+	var toPut []byte
+	if existing == 0 {
+		toPut = chunk
+	} else {
+		rc, err := h.storage.GetObject(r.Context(), key)
+		if err != nil {
+			http.Error(w, `{"error":"get existing: `+err.Error()+`"}`, 500)
+			return
+		}
+		existingData, err := io.ReadAll(rc)
+		_ = rc.Close()
+		if err != nil {
+			http.Error(w, `{"error":"read existing"}`, 500)
+			return
+		}
+		toPut = append(existingData, chunk...)
+	}
+	if err := h.storage.PutObject(r.Context(), key, bytes.NewReader(toPut), int64(len(toPut)), ct); err != nil {
+		http.Error(w, `{"error":"put: `+err.Error()+`"}`, 500)
+		return
+	}
+	uploaded := int64(len(toPut))
+	if hasTotal && uploaded == total {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "complete", "uploaded": uploaded, "total": total})
+		return
+	}
+	if hasTotal && uploaded < total {
+		w.Header().Set("Range", fmt.Sprintf("bytes=0-%d", uploaded-1))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(308)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "resume", "uploaded": uploaded, "total": total})
+		return
+	}
+	// no total -> 308
+	w.Header().Set("Range", fmt.Sprintf("bytes=0-%d", uploaded-1))
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(308)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "resume", "uploaded": uploaded})
+}
+
+// Ensure interface compliance at compile time
+var _ = regexp.MustCompile

--- a/services/upload/internal/handler/resumable_test.go
+++ b/services/upload/internal/handler/resumable_test.go
@@ -1,0 +1,125 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+type fakeResumableStorage struct {
+	data map[string][]byte
+}
+
+func newFakeResumable() *fakeResumableStorage {
+	return &fakeResumableStorage{data: map[string][]byte{}}
+}
+func (f *fakeResumableStorage) StatObject(ctx context.Context, key string) error {
+	if _, ok := f.data[key]; !ok {
+		return errFake("not found")
+	}
+	return nil
+}
+func (f *fakeResumableStorage) StatObjectSize(ctx context.Context, key string) (int64, error) {
+	if d, ok := f.data[key]; ok {
+		return int64(len(d)), nil
+	}
+	return 0, errFake("not found")
+}
+func (f *fakeResumableStorage) GetObject(ctx context.Context, key string) (io.ReadCloser, error) {
+	if d, ok := f.data[key]; ok {
+		return io.NopCloser(bytes.NewReader(d)), nil
+	}
+	return nil, errFake("not found")
+}
+func (f *fakeResumableStorage) PutObject(ctx context.Context, key string, r io.Reader, size int64, ct string) error {
+	b, _ := io.ReadAll(r)
+	f.data[key] = b
+	return nil
+}
+
+
+func newResumableRouter(h *ResumableHandler) http.Handler {
+	r := chi.NewRouter()
+	r.Get("/api/v1/videos/{id}/resumable", h.Status)
+	r.Put("/api/v1/videos/{id}/resumable", h.Upload)
+	return r
+}
+
+func TestResumableStatusEmpty(t *testing.T) {
+	st := newFakeResumable()
+	h := NewResumableHandler(st)
+	r := newResumableRouter(h)
+	req := httptest.NewRequest("GET", "/api/v1/videos/vid1/resumable", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != 200 {
+		t.Fatalf("want 200 got %d %s", w.Code, w.Body.String())
+	}
+	if !bytes.Contains(w.Body.Bytes(), []byte(`"uploaded":0`)) {
+		t.Fatalf("want uploaded 0 got %s", w.Body.String())
+	}
+}
+
+func TestResumableUploadSingleChunk(t *testing.T) {
+	st := newFakeResumable()
+	h := NewResumableHandler(st)
+	r := newResumableRouter(h)
+	// first chunk 0-4/10
+	body := bytes.Repeat([]byte("a"), 5)
+	req := httptest.NewRequest("PUT", "/api/v1/videos/vid1/resumable", bytes.NewReader(body))
+	req.Header.Set("Content-Range", "bytes 0-4/10")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != 308 {
+		t.Fatalf("want 308 got %d %s", w.Code, w.Body.String())
+	}
+	// second chunk 5-9/10
+	body2 := bytes.Repeat([]byte("b"), 5)
+	req2 := httptest.NewRequest("PUT", "/api/v1/videos/vid1/resumable", bytes.NewReader(body2))
+	req2.Header.Set("Content-Range", "bytes 5-9/10")
+	w2 := httptest.NewRecorder()
+	r.ServeHTTP(w2, req2)
+	if w2.Code != 200 {
+		t.Fatalf("want 200 got %d %s", w2.Code, w2.Body.String())
+	}
+	key := "raw/vid1/original.mp4"
+	if len(st.data[key]) != 10 {
+		t.Fatalf("want 10 bytes got %d", len(st.data[key]))
+	}
+}
+
+func TestResumableRangeMismatch(t *testing.T) {
+	st := newFakeResumable()
+	st.data["raw/vid1/original.mp4"] = bytes.Repeat([]byte("x"), 5)
+	h := NewResumableHandler(st)
+	r := newResumableRouter(h)
+	body := bytes.Repeat([]byte("a"), 5)
+	req := httptest.NewRequest("PUT", "/api/v1/videos/vid1/resumable", bytes.NewReader(body))
+	req.Header.Set("Content-Range", "bytes 0-4/10") // should be 5-9
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != 416 {
+		t.Fatalf("want 416 got %d %s", w.Code, w.Body.String())
+	}
+}
+
+func TestResumableFullPutNoRange(t *testing.T) {
+	st := newFakeResumable()
+	h := NewResumableHandler(st)
+	r := newResumableRouter(h)
+	body := bytes.Repeat([]byte("z"), 7)
+	req := httptest.NewRequest("PUT", "/api/v1/videos/vid1/resumable", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != 200 {
+		t.Fatalf("want 200 got %d %s", w.Code, w.Body.String())
+	}
+	if len(st.data["raw/vid1/original.mp4"]) != 7 {
+		t.Fatalf("want 7 got %d", len(st.data["raw/vid1/original.mp4"]))
+	}
+}

--- a/services/upload/internal/storage/minio.go
+++ b/services/upload/internal/storage/minio.go
@@ -13,10 +13,12 @@ import (
 )
 
 type MinioClient struct {
-	client   *minio.Client
-	bucket   string
-	endpoint string
-	secure   bool
+	client    *minio.Client
+	bucket    string
+	endpoint  string
+	secure    bool
+	accessKey string
+	secretKey string
 }
 
 func NewMinioClient(endpoint, accessKey, secretKey, bucket string, secure bool) (*MinioClient, error) {
@@ -38,7 +40,7 @@ func NewMinioClient(endpoint, accessKey, secretKey, bucket string, secure bool) 
 			log.Info().Str("bucket", bucket).Msg("bucket created")
 		}
 	}
-	return &MinioClient{client: cl, bucket: bucket, endpoint: endpoint, secure: secure}, nil
+	return &MinioClient{client: cl, bucket: bucket, endpoint: endpoint, secure: secure, accessKey: accessKey, secretKey: secretKey}, nil
 }
 
 func (m *MinioClient) PutObject(ctx context.Context, key string, reader io.Reader, size int64, contentType string) error {
@@ -57,27 +59,48 @@ func (m *MinioClient) PresignedPutObject(ctx context.Context, key string, expire
 	return u.String(), nil
 }
 
-// PresignedPutObjectWithURL returns presigned URL rewritten for external access.
-// MinIO generates URL with internal endpoint (e.g., minio:9000); we rewrite to external
-// URL if MINIO_PUBLIC_ENDPOINT is set (browser needs http://localhost:9000).
+// PresignedPutObjectWithURL returns presigned URL for external access.
+// Previously we rewrote host after signing, which broke AWS SigV4 (host is signed).
+// Now we generate the signature with the public host directly if provided.
 func (m *MinioClient) PresignedPutObjectExternal(ctx context.Context, key string, expires time.Duration, publicEndpoint string) (string, error) {
-	uStr, err := m.PresignedPutObject(ctx, key, expires)
-	if err != nil {
-		return "", err
-	}
 	if publicEndpoint == "" {
-		return uStr, nil
-	}
-	u, err := url.Parse(uStr)
-	if err != nil {
-		return uStr, nil
+		return m.PresignedPutObject(ctx, key, expires)
 	}
 	pub, err := url.Parse(publicEndpoint)
+	if err != nil || pub.Host == "" {
+		return m.PresignedPutObject(ctx, key, expires)
+	}
+	// Build a temporary client that signs for the public host.
+	// publicEndpoint may be http://localhost:9000 or https://...
+	pubSecure := pub.Scheme == "https"
+	// minio.New expects endpoint as host:port without scheme
+	pubEndpoint := pub.Host
+	// If pubEndpoint lacks port, minio.New will default to 443/80; keep as is.
+	tmpClient, err := minio.New(pubEndpoint, &minio.Options{
+		Creds:       credentials.NewStaticV4(m.accessKey, m.secretKey, ""),
+		Secure:      pubSecure,
+		Region:      "us-east-1",
+		BucketLookup: minio.BucketLookupPath,
+	})
 	if err != nil {
+		// fallback to rewriting (should not happen)
+		uStr, err2 := m.PresignedPutObject(ctx, key, expires)
+		if err2 != nil {
+			return "", err2
+		}
+		if u, e := url.Parse(uStr); e == nil {
+			u.Scheme = pub.Scheme
+			u.Host = pub.Host
+			return u.String(), nil
+		}
 		return uStr, nil
 	}
-	u.Scheme = pub.Scheme
-	u.Host = pub.Host
+	u, err := tmpClient.PresignedPutObject(ctx, m.bucket, key, expires)
+	if err != nil {
+		return "", fmt.Errorf("presign put %s: %w", key, err)
+	}
+	// Ensure scheme matches publicEndpoint (minio-go uses http/https based on Secure)
+	// tmpClient already uses pubSecure, so scheme is correct.
 	return u.String(), nil
 }
 

--- a/services/upload/internal/storage/minio.go
+++ b/services/upload/internal/storage/minio.go
@@ -88,3 +88,27 @@ func (m *MinioClient) StatObject(ctx context.Context, key string) error {
 	}
 	return nil
 }
+
+func (m *MinioClient) StatObjectSize(ctx context.Context, key string) (int64, error) {
+	info, err := m.client.StatObject(ctx, m.bucket, key, minio.StatObjectOptions{})
+	if err != nil {
+		return 0, fmt.Errorf("stat %s: %w", key, err)
+	}
+	return info.Size, nil
+}
+
+func (m *MinioClient) GetObject(ctx context.Context, key string) (io.ReadCloser, error) {
+	obj, err := m.client.GetObject(ctx, m.bucket, key, minio.GetObjectOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("get %s: %w", key, err)
+	}
+	return obj, nil
+}
+
+func (m *MinioClient) RemoveObject(ctx context.Context, key string) error {
+	err := m.client.RemoveObject(ctx, m.bucket, key, minio.RemoveObjectOptions{})
+	if err != nil {
+		return fmt.Errorf("remove %s: %w", key, err)
+	}
+	return nil
+}


### PR DESCRIPTION
Closes #19
Closes #20
Closes #21

## Summary
Backlog phase — 3 issues: brute-force protection for login, Content-Range resumable fallback for presigned upload, and e2e coverage for presign + private HLS.

* **auth** `services/auth/src/core/limiter.py:1` — slowapi 5/min/IP on `POST /api/v1/auth/login` with redis (`redis:7-alpine` in compose) fallback to memory; 429 after limit (`services/auth/src/routers/auth.py:60`, `services/auth/src/main.py:11`).
* **upload** `services/upload/internal/handler/resumable.go:1` — `GET /api/v1/videos/{id}/resumable` offset + `PUT /resumable` with `Content-Range: bytes start-end/total` (308 until complete, 200 when done, 416 on mismatch) via `StatObjectSize/GetObject/PutObject`; gateway proxies `/resumable` (`services/gateway/cmd/server/main.go:121`); frontend `frontend/src/lib/api.ts:158` adds `getResumableOffset/uploadResumable` with fallback in `uploadVideo`.
* **infra/e2e** `scripts/e2e.sh:262` — adds steps 8 presign `POST /presign→PUT presigned→POST /complete→poll ready→HLS`, 9 private `PATCH visibility private→403 without token→200 with hls-token + Cache-Control private`, 10 resumable `308→200` incl. 50% split resume.
* **fix** `services/upload/internal/storage/minio.go:60` — generate presigned URL for public host (`MINIO_PUBLIC_ENDPOINT`) without breaking SigV4 (tmp client Region us-east-1, BucketLookupPath); `services/gateway/cmd/server/main.go:121` — remove invalid wildcard `*/resumable` causing chi panic.

## Acceptance criteria
- [x] #19 redis in compose, slowapi 5 req/min/IP on /auth/login, 429 after limit — `curl 6× login →429`, `uv run pytest` 12 passed
- [x] #20 Content-Range handler for presign, PUT with Range resume — обрыв 50% → resume via `GET /resumable` + second `PUT` 200
- [x] #21 e2e tests presign→PUT→complete→ready→master.m3u8→ffprobe + private HLS 403/200 + old POST /upload — `make e2e` PASS

## Verification
- [x] `make lint-go` — 0 issues
- [x] `make lint-py` — black/flake8/mypy pass
- [x] `make lint-front` — next lint 0 warnings
- [x] `make test-go` — upload handler 13 passed (incl. 4 resumable)
- [x] `make test-py` — auth 12 passed (incl. rate-limit), transcoder 20 passed
- [x] `make up --build -d && make e2e` — PASS (presign 200, private 403→200, resumable 308→200)

## Remaining risks
- resumable append is Get+append+Put (O(n) re-upload per chunk) — ok for e2e 32KB sample, not for 5GB multi-chunk (accepted for backlog; MinIO multipart would be next step)
- limiter falls back to memory when redis unreachable locally (probe in limiter.py) — in compose redis is reachable, limits distributed